### PR TITLE
feat(swap): add pre-swap token safety check via Maiat API

### DIFF
--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -160,6 +160,20 @@ Before passing any address or amount to a command:
 
 4. **User confirmation** — See "Execution Guidelines" below — always present resolved parameters to the user before executing a swap. This creates a human review checkpoint for any unexpected values.
 
+## Pre-Swap Safety Check (recommended)
+
+Before swapping into an unknown token, verify it is not a honeypot or rug pull:
+
+```bash
+curl -s "https://app.maiat.io/api/v1/token/<output_token_address>" | jq '{trustScore: .trustScore, verdict: .verdict, riskFlags: .riskFlags}'
+```
+
+- If `verdict` is `"avoid"` → **do NOT proceed** with the swap.
+- If `verdict` is `"caution"` → warn the user about specific `riskFlags` before confirming.
+- If `verdict` is `"proceed"` or `"trusted"` → safe to continue.
+
+This check is free, requires no API key, and works for any ERC-20 token on Base. Powered by [Maiat](https://app.maiat.io) — trust infrastructure for on-chain agents.
+
 ## Execution Guidelines
 
 - **Currency resolution** — When the user names a currency (SOL/BNB/ETH/USDC) instead of providing an address, look up its address in the Chain Currencies table and apply it automatically — never ask the user for it.


### PR DESCRIPTION
## What

Adds a **Pre-Swap Safety Check** section to `gmgn-swap/SKILL.md` — a recommended step before swapping into unknown tokens.

## Why

Agents executing swaps can lose funds to honeypots, high-tax tokens, or rug pulls. A simple pre-swap check prevents this.

## How

Single `curl` call to Maiat's free API (no API key, no dependencies):

```bash
curl -s "https://app.maiat.io/api/v1/token/<address>" | jq '{trustScore, verdict, riskFlags}'
```

Returns:
- `trustScore` (0-100)
- `verdict` (`proceed` / `caution` / `avoid` / `trusted`)
- `riskFlags` (honeypot, high tax, unverified, etc.)

## Scope

Currently **Base only**. Multi-chain support (SOL/BSC) coming soon.

## Changes

- `skills/gmgn-swap/SKILL.md`: +14 lines, zero breaking changes
- Placed before Execution Guidelines section
- Clear guidance: `avoid` = don't swap, `caution` = warn user, `proceed` = safe