### PR TITLE
Fix Node engine floor for undici

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,8 @@ Config lookup order: `~/.config/gmgn/.env` → project `.env` (project takes pre
 
 Install a pinned version to avoid pulling untrusted updates at runtime:
 
+Requires Node.js 18.17 or newer.
+
 ```bash
 npm install -g gmgn-cli@1.0.1
 ```

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -85,6 +85,8 @@ cp .env.example .env
 
 安装固定版本，避免运行时拉取未经验证的更新：
 
+需要 Node.js 18.17 或更高版本。
+
 ```bash
 npm install -g gmgn-cli@1.0.1
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^12.1.0",
         "dotenv": "^16.4.5",
         "socks": "^2.8.7",
-        "undici": "^7.24.1"
+        "undici": "^6.24.1"
       },
       "bin": {
         "gmgn-cli": "dist/index.js"
@@ -23,7 +23,7 @@
         "typescript": "^5.5.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -647,12 +647,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
-      "license": "MIT",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
     "socks": "^2.8.7",
-    "undici": "^7.24.1"
+    "undici": "^6.24.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -31,7 +31,7 @@
     "typescript": "^5.5.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "license": "MIT",
   "repository": {

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -19,6 +19,7 @@ Use the `gmgn-cli` tool to query K-line data for a token or browse trending toke
 
 ## Prerequisites
 
+- Node.js 18.17 or newer
 - `.env` file with `GMGN_API_KEY` set
 - Run from the directory where your `.env` file is located, or set `GMGN_HOST` in your environment
 - `gmgn-cli` installed globally: `npm install -g gmgn-cli@1.0.1`

--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -22,6 +22,7 @@ Use the `gmgn-cli` tool to query wallet portfolio data based on the user's reque
 
 ## Prerequisites
 
+- Node.js 18.17 or newer
 - `.env` file with `GMGN_API_KEY` set
 - Run from the directory where your `.env` file is located, or set `GMGN_HOST` in your environment
 - `gmgn-cli` installed globally: `npm install -g gmgn-cli@1.0.1`

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -40,6 +40,8 @@ Currency tokens are the base/native assets of each chain. They are used to buy o
 
 ## Prerequisites
 
+Node.js 18.17 or newer is required.
+
 Both `GMGN_API_KEY` and `GMGN_PRIVATE_KEY` must be set in `.env`. The private key must correspond to the wallet bound to the API Key.
 
 `gmgn-cli` must be installed globally before use (one-time setup):

--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -22,6 +22,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 
 ## Prerequisites
 
+- Node.js 18.17 or newer
 - `.env` file with `GMGN_API_KEY` set
 - Run from the directory where your `.env` file is located, or set `GMGN_HOST` in your environment
 - `gmgn-cli` installed globally: `npm install -g gmgn-cli@1.0.1`


### PR DESCRIPTION
## Summary
- pin `undici` to `^6.24.1`, which matches the Node 18 support line and removes the Node 20-only runtime requirement
- raise `engines.node` to `>=18.17.0` so the package metadata matches the actual supported runtime floor
- update the English/Chinese README and GMGN skill prerequisites to document the Node 18.17+ requirement

## Testing
- `PATH="$HOME/.nvm/versions/node/v20.18.3/bin:$PATH" npm run build`
- `PATH="$HOME/.nvm/versions/node/v20.18.3/bin:$PATH" node dist/index.js market trending --chain sol --interval 1h --limit 1 --raw`
- `NPM_CONFIG_CACHE=/tmp/npm-cache npx -y node@18.17.1 dist/index.js --help`
- `NPM_CONFIG_CACHE=/tmp/npm-cache npx -y node@18.17.1 dist/index.js market trending --chain sol --interval 1h --limit 1 --raw`
- `NPM_CONFIG_CACHE=/tmp/npm-cache npm audit --json`

Closes #25
