### PR TITLE
feat(market): update trending --interval to support 1m/5m

### DIFF
--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -30,7 +30,7 @@ export function registerMarketCommands(program: Command): void {
     .command("trending")
     .description("Get trending token swap data")
     .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
-    .requiredOption("--interval <interval>", "Time interval: 1h / 3h / 6h / 24h")
+    .requiredOption("--interval <interval>", "Time interval: 1m / 5m / 1h / 6h / 24h")
     .option("--limit <n>", "Number of results (default 100, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: default / volume / swaps / marketcap / holder_count / price / change1h / ... (see docs for full list)")
     .option("--direction <dir>", "Sort direction: asc / desc")


### PR DESCRIPTION
Closes #31

## Summary

- Add `1m` and `5m` as valid values for `--interval` in `market trending`
- Remove `3h` which is not a supported API interval
- Updated interval list: `1m / 5m / 1h / 6h / 24h`

## Changes

- `src/commands/market.ts`: update `--interval` description string

## Test plan

- [ ] `gmgn-cli market trending --chain sol --interval 1m` returns data
- [ ] `gmgn-cli market trending --chain sol --interval 5m` returns data
- [ ] `gmgn-cli market trending --chain sol --interval 3h` should be rejected or return error

🤖 Generated with [Claude Code](https://claude.com/claude-code)