### PR TITLE
feat(market): add structured options for trenches command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -277,6 +277,12 @@ npx gmgn-cli market trending \
   --interval 1h \
   --order-by volume --limit 20 \
   --filter not_risk --filter not_honeypot
+
+npx gmgn-cli market trenches \
+  --chain sol \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform Pump.fun --launchpad-platform pump_mayhem --launchpad-platform letsbonk \
+  --limit 80
 ```
 
 ### Portfolio

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -277,6 +277,12 @@ npx gmgn-cli market trending \
   --interval 1h \
   --order-by volume --limit 20 \
   --filter not_risk --filter not_honeypot
+
+npx gmgn-cli market trenches \
+  --chain sol \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform Pump.fun --launchpad-platform pump_mayhem --launchpad-platform letsbonk \
+  --limit 80
 ```
 
 ### Portfolio

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -260,14 +260,17 @@ npx gmgn-cli portfolio token-balance \
 Query Trenches token lists (new creation, near completion, completed).
 
 ```bash
-npx gmgn-cli market trenches --chain <chain> [--raw]
+npx gmgn-cli market trenches --chain <chain> [--type <type...>] [--launchpad-platform <platform...>] [--limit <n>] [--raw]
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
+| `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
+| `--limit` | No | Max results per category, max 80 (default: 80) |
 
-**Response:** `data.new_creation`, `data.pump`, `data.completed` — each is an array of `RankItem` (same structure as `market trending` rank items).
+**Response:** `data.new_creation`, `data.pump`, `data.completed` — each is an array of `RankItem` (same structure as `market trending` rank items). **Note: `data.pump` in the response corresponds to `--type near_completion` in the request. The API always returns this category under the key `pump`, not `near_completion`.**
 
 ---
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -141,12 +141,178 @@ For each token, offer:
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
+| `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
+| `--limit` | No | Max results per category, max 80 (default: 80) |
 
-Response fields: `data.new_creation`, `data.pump`, `data.completed` — each is an array of `RankItem` (same fields as `market trending` rank items).
+Response fields: `data.new_creation`, `data.pump`, `data.completed` — each is an array of `RankItem` (same fields as `market trending` rank items). **Important: `data.pump` in the response corresponds to `--type near_completion` in the request. The API always returns this category under the key `pump`, not `near_completion`.**
+
+### Response Item Key Reference
+
+**Basic Info**
+
+| Field | Description |
+|-------|-------------|
+| `address` | Token contract address |
+| `symbol` / `name` | Token symbol and name |
+| `launchpad_platform` | Launch platform (e.g. `Pump.fun`, `letsbonk`) |
+| `exchange` | Current exchange (e.g. `pump_amm`, `raydium`) |
+| `usd_market_cap` | Market cap in USD |
+| `liquidity` | Liquidity in USD |
+| `total_supply` | Total token supply |
+| `created_timestamp` | Creation time (Unix seconds) |
+| `open_timestamp` | Open market listing time (Unix seconds, `completed` only) |
+| `complete_timestamp` | Bonding curve completion time (Unix seconds) |
+| `complete_cost_time` | Time from creation to completion in seconds |
+
+**Trading Data**
+
+| Field | Description |
+|-------|-------------|
+| `swaps_1m` / `swaps_1h` / `swaps_24h` | Swap count per time window |
+| `volume_1h` / `volume_24h` | Trading volume in USD |
+| `buys_24h` / `sells_24h` | Buy / sell count in 24h |
+| `net_buy_24h` | Net buy volume in 24h |
+| `holder_count` | Number of token holders |
+
+**Security & Risk**
+
+| Field | Chains | Description |
+|-------|--------|-------------|
+| `renounced_mint` | SOL | Whether mint authority is renounced (SOL-specific concept; always `false` on EVM chains) |
+| `renounced_freeze_account` | SOL | Whether freeze authority is renounced (SOL-specific concept; always `false` on EVM chains) |
+| `burn_status` | all | Liquidity burn status |
+| `rug_ratio` | all | Rug pull risk ratio |
+| `top_10_holder_rate` | all | Top 10 holders concentration ratio |
+| `rat_trader_amount_rate` | all | Insider / sneak trading volume ratio |
+| `bundler_trader_amount_rate` | all | Bundle trading volume ratio |
+| `is_wash_trading` | all | Whether wash trading is detected |
+| `sniper_count` | all | Number of sniper wallets |
+| `suspected_insider_hold_rate` | all | Suspected insider holding ratio |
+| `open_source` | all | Whether contract source code is verified (`"yes"` / `"no"` / `"unknown"`) |
+| `owner_renounced` | all | Whether contract ownership is renounced (`"yes"` / `"no"` / `"unknown"`) |
+| `is_honeypot` | BSC / Base | Whether token is a honeypot (`"yes"` / `"no"`); returns empty string on SOL (not applicable) |
+| `buy_tax` | all | Buy tax ratio (e.g. `0.03` = 3%) |
+| `dev_team_hold_rate` | all | Dev team holding ratio |
+
+**Dev Holdings**
+
+| Field | Description |
+|-------|-------------|
+| `creator_token_status` | Dev holding status (e.g. `creator_hold`, `creator_close`) |
+| `creator_balance_rate` | Dev holding ratio as a proportion of total supply |
+
+**Smart Money**
+
+| Field | Description |
+|-------|-------------|
+| `smart_degen_count` | Number of smart money holders |
+| `renowned_count` | Number of renowned wallet holders (KOL) |
+
+**Social Media**
+
+| Field | Description |
+|-------|-------------|
+| `twitter` | Twitter / X link |
+| `telegram` | Telegram link |
+| `website` | Website link |
+| `instagram` | Instagram link |
+| `tiktok` | TikTok link |
+| `has_at_least_one_social` | Whether any social media link exists |
+| `x_user_follower` | Twitter follower count |
+| `cto_flag` | Whether community takeover (CTO) has occurred |
+
+**Dexscreener Marketing**
+
+| Field | Description |
+|-------|-------------|
+| `dexscr_ad` | Whether a Dexscreener ad has been placed |
+| `dexscr_update_link` | Whether social links have been updated on Dexscreener |
+| `dexscr_trending_bar` | Whether paid for Dexscreener trending bar placement |
+| `dexscr_boost_fee` | Amount paid for Dexscreener boost (0 = none) |
+
+### Solana Trenches Examples
 
 ```bash
-# Trenches token lists on SOL
-gmgn-cli market trenches --chain sol --raw
+# All three categories at once
+gmgn-cli market trenches --chain sol --raw \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform Pump.fun --launchpad-platform pump_mayhem --launchpad-platform pump_mayhem_agent --launchpad-platform pump_agent --launchpad-platform letsbonk --launchpad-platform bonkers --launchpad-platform bags \
+  --limit 80
+
+# New creation only
+gmgn-cli market trenches --chain sol --raw \
+  --type new_creation \
+  --launchpad-platform Pump.fun --launchpad-platform pump_mayhem --launchpad-platform pump_mayhem_agent --launchpad-platform pump_agent --launchpad-platform letsbonk --launchpad-platform bonkers --launchpad-platform bags \
+  --limit 80
+
+# Near completion only
+gmgn-cli market trenches --chain sol --raw \
+  --type near_completion \
+  --launchpad-platform Pump.fun --launchpad-platform pump_mayhem --launchpad-platform pump_mayhem_agent --launchpad-platform pump_agent --launchpad-platform letsbonk --launchpad-platform bonkers --launchpad-platform bags \
+  --limit 80
+
+# Completed (open market) only
+gmgn-cli market trenches --chain sol --raw \
+  --type completed \
+  --launchpad-platform Pump.fun --launchpad-platform pump_mayhem --launchpad-platform pump_mayhem_agent --launchpad-platform pump_agent --launchpad-platform letsbonk --launchpad-platform bonkers --launchpad-platform bags \
+  --limit 80
+```
+
+### BSC Trenches Examples
+
+```bash
+# All three categories at once
+gmgn-cli market trenches --chain bsc --raw \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform fourmeme --launchpad-platform fourmeme_agent --launchpad-platform bn_fourmeme --launchpad-platform four_xmode_agent --launchpad-platform flap --launchpad-platform clanker --launchpad-platform lunafun \
+  --limit 80
+
+# New creation only
+gmgn-cli market trenches --chain bsc --raw \
+  --type new_creation \
+  --launchpad-platform fourmeme --launchpad-platform fourmeme_agent --launchpad-platform bn_fourmeme --launchpad-platform four_xmode_agent --launchpad-platform flap --launchpad-platform clanker --launchpad-platform lunafun \
+  --limit 80
+
+# Near completion only
+gmgn-cli market trenches --chain bsc --raw \
+  --type near_completion \
+  --launchpad-platform fourmeme --launchpad-platform fourmeme_agent --launchpad-platform bn_fourmeme --launchpad-platform four_xmode_agent --launchpad-platform flap --launchpad-platform clanker --launchpad-platform lunafun \
+  --limit 80
+
+# Completed (open market) only
+gmgn-cli market trenches --chain bsc --raw \
+  --type completed \
+  --launchpad-platform fourmeme --launchpad-platform fourmeme_agent --launchpad-platform bn_fourmeme --launchpad-platform four_xmode_agent --launchpad-platform flap --launchpad-platform clanker --launchpad-platform lunafun \
+  --limit 80
+```
+
+### Base Trenches Examples
+
+```bash
+# All three categories at once
+gmgn-cli market trenches --chain base --raw \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform clanker --launchpad-platform bankr --launchpad-platform flaunch --launchpad-platform zora --launchpad-platform zora_creator --launchpad-platform baseapp --launchpad-platform basememe --launchpad-platform virtuals_v2 --launchpad-platform klik \
+  --limit 80
+
+# New creation only
+gmgn-cli market trenches --chain base --raw \
+  --type new_creation \
+  --launchpad-platform clanker --launchpad-platform bankr --launchpad-platform flaunch --launchpad-platform zora --launchpad-platform zora_creator --launchpad-platform baseapp --launchpad-platform basememe --launchpad-platform virtuals_v2 --launchpad-platform klik \
+  --limit 80
+
+# Near completion only
+gmgn-cli market trenches --chain base --raw \
+  --type near_completion \
+  --launchpad-platform clanker --launchpad-platform bankr --launchpad-platform flaunch --launchpad-platform zora --launchpad-platform zora_creator --launchpad-platform baseapp --launchpad-platform basememe --launchpad-platform virtuals_v2 --launchpad-platform klik \
+  --limit 80
+
+# Completed (open market) only
+gmgn-cli market trenches --chain base --raw \
+  --type completed \
+  --launchpad-platform clanker --launchpad-platform bankr --launchpad-platform flaunch --launchpad-platform zora --launchpad-platform zora_creator --launchpad-platform baseapp --launchpad-platform basememe --launchpad-platform virtuals_v2 --launchpad-platform klik \
+  --limit 80
 ```
 
 ## Notes

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -126,8 +126,8 @@ export class OpenApiClient {
     return this.normalRequest("GET", "/v1/user/wallet_token_balance", { chain, wallet_address: walletAddress, token_address: tokenAddress });
   }
 
-  async getTrenches(chain: string): Promise<unknown> {
-    const body = buildTrenchesBody(chain);
+  async getTrenches(chain: string, types?: string[], platforms?: string[], limit?: number): Promise<unknown> {
+    const body = buildTrenchesBody(chain, types, platforms, limit);
     return this.normalRequest("POST", "/v1/trenches", { chain }, body);
   }
 
@@ -330,21 +330,23 @@ const TRENCHES_QUOTE_ADDRESS_TYPES: Record<string, number[]> = {
   base: [11, 3, 12, 13, 0],
 };
 
-function buildTrenchesBody(chain: string): Record<string, unknown> {
-  const launchpad_platform = TRENCHES_PLATFORMS[chain] ?? [];
+function buildTrenchesBody(chain: string, types?: string[], platforms?: string[], limit?: number): Record<string, unknown> {
+  const selectedTypes = types?.length ? types : ["new_creation", "near_completion", "completed"];
+  const launchpad_platform = platforms?.length ? platforms : (TRENCHES_PLATFORMS[chain] ?? []);
   const quote_address_type = TRENCHES_QUOTE_ADDRESS_TYPES[chain] ?? [];
+  const actualLimit = limit ?? 80;
   const section = {
     filters: ["offchain", "onchain"],
     launchpad_platform,
     quote_address_type,
     launchpad_platform_v2: true,
+    limit: actualLimit,
   };
-  return {
-    new_creation:    { ...section, limit: 60 },
-    near_completion: { ...section, limit: 120 },
-    completed:       { ...section, limit: 60 },
-    version: "v2",
-  };
+  const body: Record<string, unknown> = { version: "v2" };
+  for (const type of selectedTypes) {
+    body[type] = { ...section };
+  }
+  return body;
 }
 
 function buildUrl(base: string, query: Record<string, string | number | string[]>): string {

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -61,11 +61,14 @@ export function registerMarketCommands(program: Command): void {
     .command("trenches")
     .description("Get Trenches token data (new creation, near completion, completed)")
     .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .option("--type <type...>", "Categories to query, repeatable: new_creation / near_completion / completed (default: all three)")
+    .option("--launchpad-platform <platform...>", "Launchpad platform filter, repeatable (default: all platforms for the chain)")
+    .option("--limit <n>", "Max results per category, max 80 (default: 80)", parseInt)
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       validateChain(opts.chain);
       const client = new OpenApiClient(getConfig());
-      const data = await client.getTrenches(opts.chain).catch(exitOnError);
+      const data = await client.getTrenches(opts.chain, opts.type, opts.launchpadPlatform, opts.limit).catch(exitOnError);
       printResult(data, opts.raw);
     });
 }


### PR DESCRIPTION
## Summary

- Replace raw `--body <json>` parameter with structured CLI flags: `--type`, `--launchpad-platform`, `--limit`
- Add complete response key reference to SKILL.md (security, dev holdings, smart money, social, Dexscreener marketing fields with chain-specific notes)
- Add SOL / BSC / Base chain examples to SKILL.md and docs/cli-usage.md
- Clarify that API response key `data.pump` corresponds to request type `near_completion`
- Update Readme.md and Readme.zh.md with trenches CLI examples

## Test plan
- [x] `npm run build` passes with no errors
- [x] `gmgn-cli market trenches --help` shows new options
- [x] Tested `--type`, `--launchpad-platform`, `--limit` against SOL chain — correct filtering confirmed
- [x] Verified `data.pump` = `near_completion` category via live API response
