### PR TITLE
docs: add upgrade tutorial section to README (en + zh)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -325,7 +325,39 @@ npx gmgn-cli order get --chain sol --order-id <order-id>
 
 ---
 
-## 9. Security & Disclaimer
+## 9. Upgrade Skills and CLI
+
+To upgrade `gmgn-cli` and Skills to the latest version:
+
+**Via AI Agent (recommended)**
+
+Send this to your AI agent:
+
+```
+Run these two commands to update gmgn-cli and the skills:
+1. npm install -g gmgn-cli
+2. npx skills add GMGNAI/gmgn-skills
+```
+
+**Via CLI**
+
+```bash
+# Upgrade gmgn-cli
+npm install -g gmgn-cli
+
+# Upgrade Skills
+npx skills add GMGNAI/gmgn-skills
+```
+
+**Check the current version**
+
+```bash
+gmgn-cli --version
+```
+
+---
+
+## 10. Security & Disclaimer
 
 **About `GMGN_PRIVATE_KEY`**
 

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -404,7 +404,39 @@ npx gmgn-cli order get --chain sol --order-id <order-id>
 
 ---
 
-## 9. 安全与免责
+## 9. 升级 Skills 和 CLI
+
+将 `gmgn-cli` 和 Skills 升级到最新版本：
+
+**方式一：通过 AI Agent（推荐）**
+
+发送给你的 AI Agent：
+
+```
+运行以下两条命令，更新 gmgn-cli 和 Skills 文档：
+1. npm install -g gmgn-cli
+2. npx skills add GMGNAI/gmgn-skills
+```
+
+**方式二：通过 CLI**
+
+```bash
+# 升级 gmgn-cli
+npm install -g gmgn-cli
+
+# 升级 Skills
+npx skills add GMGNAI/gmgn-skills
+```
+
+**查看当前版本号**
+
+```bash
+gmgn-cli --version
+```
+
+---
+
+## 10. 安全与免责
 
 **关于 `GMGN_PRIVATE_KEY`**
 


### PR DESCRIPTION
## Summary

- Add section 9 "Upgrade Skills and CLI" between Supported Chains (§8) and Security (§10)
- Covers three sub-topics: upgrade via AI Agent prompt, upgrade via CLI commands, and version check (`gmgn-cli --version`)
- Applied to both `Readme.md` (English) and `Readme.zh.md` (Chinese)

## Test plan

- [ ] Verify section numbering is correct (§9 Upgrade, §10 Security)
- [ ] Check markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)