### PR TITLE
[codex] Fix strategy list signature auth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -525,7 +525,7 @@ gmgn-cli order strategy create \
   --amount-in-percent 100 \
   --slippage 0.01
 
-# List open strategy orders
+# List open strategy orders (requires private key)
 gmgn-cli order strategy list --chain sol
 
 # Cancel a strategy order

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -557,7 +557,7 @@ gmgn-cli order strategy create \
   --amount-in-percent 100 \
   --slippage 0.01
 
-# 查看当前挂单
+# 查看当前挂单（需要私钥）
 gmgn-cli order strategy list --chain sol
 
 # 撤销策略单

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -532,7 +532,7 @@ gmgn-cli order strategy create \
 
 ## order strategy list
 
-List strategy orders. Uses normal auth.
+List strategy orders. **Requires `GMGN_PRIVATE_KEY` configured in `.env`.**
 
 ```bash
 gmgn-cli order strategy list --chain <chain> [--type <open|history>] [--from <address>] [--group-tag <tag>] [--base-token <address>] [--page-token <token>] [--limit <n>] [--raw]

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -49,7 +49,7 @@ Use the `gmgn-cli` tool to submit a token swap or query an existing order. **Req
 | `order quote` | Get a swap quote (no transaction submitted) |
 | `order get` | Query order status |
 | `order strategy create` | Create a limit/strategy order (requires private key) |
-| `order strategy list` | List strategy orders (normal auth) |
+| `order strategy list` | List strategy orders (requires private key) |
 | `order strategy cancel` | Cancel a strategy order (requires private key) |
 
 ## Supported Chains
@@ -383,7 +383,7 @@ gmgn-cli order strategy cancel \
 - Swap uses **critical auth** (API Key + signature) — CLI handles signing automatically, no manual processing needed
 - After submitting a swap, use `order get` to poll for confirmation
 - `--amount` is in the **smallest unit** (e.g., lamports for SOL)
-- `order strategy create` and `order strategy cancel` use critical auth (require `GMGN_PRIVATE_KEY`); `order strategy list` uses normal auth
+- `order strategy create`, `order strategy list`, and `order strategy cancel` use critical auth (require `GMGN_PRIVATE_KEY`)
 - Use `--raw` to get single-line JSON for further processing
 
 ## Input Validation

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -306,14 +306,14 @@ export class OpenApiClient {
     return this.criticalRequest("GET", "/v1/trade/query_order", { order_id: orderId, chain }, null);
   }
 
-  // ---- Strategy order endpoints ----
+  // ---- Strategy order endpoints (critical auth) ----
 
   async createStrategyOrder(params: StrategyCreateParams): Promise<unknown> {
     return this.criticalRequest("POST", "/v1/trade/strategy/create", {}, params);
   }
 
   async getStrategyOrders(chain: string, extra: Record<string, string | number> = {}): Promise<unknown> {
-    return this.normalRequest("GET", "/v1/trade/strategy/orders", { chain, ...extra });
+    return this.criticalRequest("GET", "/v1/trade/strategy/orders", { chain, ...extra }, null);
   }
 
   async cancelStrategyOrder(params: StrategyCancelParams): Promise<unknown> {

--- a/src/commands/swap.ts
+++ b/src/commands/swap.ts
@@ -170,7 +170,7 @@ export function registerSwapCommands(program: Command): void {
 
   strategy
     .command("list")
-    .description("List strategy orders (normal auth)")
+    .description("List strategy orders (requires private key)")
     .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
     .option("--type <type>", "open (default) / history")
     .option("--from <address>", "Filter by wallet address")
@@ -188,7 +188,7 @@ export function registerSwapCommands(program: Command): void {
       if (opts.baseToken) extra["base_token"] = opts.baseToken;
       if (opts.pageToken) extra["page_token"] = opts.pageToken;
       if (opts.limit != null) extra["limit"] = opts.limit;
-      const client = new OpenApiClient(getConfig());
+      const client = new OpenApiClient(getConfig(true));
       const data = await client.getStrategyOrders(opts.chain, extra).catch(exitOnError);
       printResult(data, opts.raw);
     });


### PR DESCRIPTION
## Summary
- switch `order strategy list` from normal auth to signature-based critical auth
- update the CLI command to require `GMGN_PRIVATE_KEY` when listing strategy orders
- correct the related docs and skill text so they match actual API behavior

## Root cause
`GET /v1/trade/strategy/orders` was implemented through `normalRequest()`, so the CLI never sent `X-Signature`. The backend expects a signature for this route and returns `401 AUTH_INVALID` with `missing signature`.

## Validation
- `npm run build`

## Impact
This fixes issue #72 by making `gmgn-cli order strategy list --chain sol` use the same auth model the endpoint actually requires.

Fixes #72