### PR TITLE
docs(gmgn-token): add private_vault_hold_rate field to stat object reference

### DIFF
--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -237,6 +237,7 @@ The response has five nested objects: `pool`, `dev`, `link`, `stat`, `wallet_tag
 | `stat.bot_degen_count` | Number of bot degen wallets |
 | `stat.bot_degen_rate` | Ratio of bot degen wallets |
 | `stat.fresh_wallet_rate` | Ratio of fresh/new wallets among holders |
+| `stat.private_vault_hold_rate` | Ratio held by private vault (vanish) addresses — displayed as "vanish" in GMGN UI (0–1) |
 
 **`wallet_tags_stat` Object** — Wallet type breakdown
 


### PR DESCRIPTION
## Summary

- Add `stat.private_vault_hold_rate` field to the `token info` Response Field Reference table in `skills/gmgn-token/SKILL.md`
- This field is returned by the `GET /v1/token/info` API but was missing from the documentation
- Clarifies that this field corresponds to the "vanish" metric displayed in the GMGN UI

## Change

Added one row to the `stat` Object table:

| Field | Description |
|-------|-------------|
| `stat.private_vault_hold_rate` | Ratio held by private vault (vanish) addresses — displayed as "vanish" in GMGN UI (0–1) |