### PR TITLE
docs(gmgn-portfolio): add created_at field to portfolio stats common object

### DIFF
--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -228,6 +228,7 @@ The response also includes a `common` object when available (absent if the upstr
 | `common.follow_count` | Number of GMGN users following this wallet |
 | `common.remark_count` | Number of GMGN users who have remarked this wallet |
 | `common.created_token_count` | Tokens created by this wallet |
+| `common.created_at` | Wallet creation time (Unix seconds) — records when the first funding transaction arrived; use this as the wallet's age indicator |
 | `common.fund_from` | Funding source label |
 | `common.fund_from_address` | Address that funded this wallet |
 | `common.fund_amount` | Funding amount |


### PR DESCRIPTION
## Summary

- Add `common.created_at` field to the `portfolio stats` Response Field Reference table in `skills/gmgn-portfolio/SKILL.md`
- This field is returned by the `GET /v1/user/wallet_stats` API but was missing from the documentation

## Change

Added one row to the `common` object table:

| Field | Description |
|-------|-------------|
| `common.created_at` | Wallet creation time (Unix seconds) — records when the first funding transaction arrived; use this as the wallet's age indicator |