### PR TITLE
docs(gmgn-swap): add order strategy commands to argument-hint

### DIFF
--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-swap
 description: "[FINANCIAL EXECUTION] Submit a real blockchain token swap or query order status. Executes irreversible on-chain transactions. Requires explicit user confirmation before every swap. Supports sol / bsc / base."
-argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>]"
+argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>] | [order strategy list --chain <chain> --group-tag <LimitOrder|STMix>] | [order strategy create --chain <chain> --order-type limit_order --sub-order-type <buy_low|buy_high|stop_loss|take_profit> ...]"
 metadata:
   cliHelp: "gmgn-cli swap --help"
 ---


### PR DESCRIPTION
## Summary

- Add `order strategy list --group-tag <LimitOrder|STMix>` to `argument-hint` — `--group-tag` is now a required parameter
- Add `order strategy create --order-type limit_order --sub-order-type <...>` to `argument-hint` — `--order-type` is now a required parameter
- Reflects command changes merged after 2026-04-07

## Test plan

- [ ] Verify `argument-hint` renders correctly when skill is invoked
- [ ] Confirm no YAML parsing errors (value is quoted, `|` characters are safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)