### PR TITLE
docs(track): clarify description with "crypto token trading activity"

### DIFF
--- a/skills/gmgn-track/SKILL.md
+++ b/skills/gmgn-track/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmgn-track
-description: Get real-time trade activity from Smart Money wallets, KOL influencer wallets, and personally followed wallets via GMGN API. Use when user asks what smart money is buying, KOL trades, whale moves, copy-trading signals, or recent trades from followed wallets on Solana, BSC, or Base.
+description: Get real-time crypto token trading activity from Smart Money wallets, KOL influencer wallets, and personally followed wallets via GMGN API. Use when user asks what smart money is buying, KOL trades, whale moves, copy-trading signals, or recent trades from followed wallets on Solana, BSC, or Base.
 argument-hint: "<follow-wallet|kol|smartmoney> [--chain <sol|bsc|base>] [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli track --help"


### PR DESCRIPTION
## Summary

- Refined `gmgn-track` description: replaced vague "trade activity" with "crypto token trading activity" to be more specific and searchable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)