### PR TITLE
feat(eth): add Ethereum mainnet chain support (P0 commands)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This includes: trending tokens, token info, security checks, K-line / price hist
 
 ## Project Overview
 
-This is a **Claude Code plugin** — a collection of GMGN OpenAPI skills for on-chain operations. It provides CLI tools and skills for token queries, market data, wallet portfolio analysis, and swap execution across sol / bsc / base.
+This is a **Claude Code plugin** — a collection of GMGN OpenAPI skills for on-chain operations. It provides CLI tools and skills for token queries, market data, wallet portfolio analysis, and swap execution across sol / bsc / base / eth.
 
 ## Available Skills
 

--- a/Readme.md
+++ b/Readme.md
@@ -579,7 +579,7 @@ gmgn-cli multi-swap \
   --slippage 0.01
 ```
 
-> `order quote` uses critical auth on `sol` / `bsc` / `base` and requires `GMGN_PRIVATE_KEY`.
+> `order quote` uses critical auth on `sol` / `bsc` / `base` / `eth` and requires `GMGN_PRIVATE_KEY`.
 
 ### Swap with Take-Profit / Stop-Loss Orders (requires private key)
 
@@ -672,8 +672,8 @@ gmgn-cli cooking \
 
 | Commands | Chains | Chain Currencies |
 |----------|--------|-----------------|
-| token / market / portfolio / track | `sol` / `bsc` / `base` | — |
-| swap / order | `sol` / `bsc` / `base` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC |
+| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` | — |
+| swap / order | `sol` / `bsc` / `base` / `eth` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC · eth: ETH, USDC |
 
 ---
 

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -603,7 +603,7 @@ gmgn-cli multi-swap \
   --slippage 0.01
 ```
 
-> `order quote` 在 `sol` / `bsc` / `base` 上都走关键鉴权，必须配置 `GMGN_PRIVATE_KEY`。
+> `order quote` 在 `sol` / `bsc` / `base` / `eth` 上都走关键鉴权，必须配置 `GMGN_PRIVATE_KEY`。
 
 ### 带止盈止损的 Swap（需要私钥）
 
@@ -696,8 +696,8 @@ gmgn-cli cooking \
 
 | 接口类型 | 支持的链 | 链原生货币 |
 |----------|----------|-----------|
-| token / market / portfolio / track | `sol` / `bsc` / `base` | — |
-| swap / order | `sol` / `bsc` / `base` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC |
+| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` | — |
+| swap / order | `sol` / `bsc` / `base` / `eth` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC · eth: ETH、USDC |
 
 ---
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-market
-description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, and newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.) via GMGN API on Solana, BSC, or Base. Use when user asks for price chart, trending tokens, what's pumping, hot coins, new launches, token signals, or wants to discover early-stage opportunities.
-argument-hint: "kline --chain <sol|bsc|base> --address <token_address> --resolution <1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base> | signal --chain <sol|bsc>"
+description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, and newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks for price chart, trending tokens, what's pumping, hot coins, new launches, token signals, or wants to discover early-stage opportunities.
+argument-hint: "kline --chain <sol|bsc|base|eth> --address <token_address> --resolution <1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base> | signal --chain <sol|bsc>"
 metadata:
   cliHelp: "gmgn-cli market --help"
 ---
@@ -18,7 +18,7 @@ Use the `gmgn-cli` tool to query K-line data for a token, browse trending tokens
 
 - **`--filter` chain defaults** — SOL and EVM chains have different default safety filters that are applied automatically when `--filter` is omitted. Do not assume the same defaults apply across chains:
   - **SOL**: defaults to `renounced frozen` (mint and freeze authority renounced)
-  - **BSC / Base (EVM)**: defaults to `not_honeypot verified renounced`
+  - **BSC / Base / ETH (EVM)**: defaults to `not_honeypot verified renounced`
   - Omitting `--filter` is NOT the same as "no filter" — the chain defaults are always applied. To use a custom filter set, explicitly specify all desired filter tags.
 
 - **`volume` vs `amount` (kline)** — Naming is counterintuitive. `volume` = USD dollar value of trades; `amount` = token units traded. For a token priced at $0.0002, these differ by 5,000×. Always use `volume` for "how much USD was traded" and `amount` for "how many tokens changed hands."
@@ -52,7 +52,7 @@ Use the `gmgn-cli` tool to query K-line data for a token, browse trending tokens
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` (signal: `sol` / `bsc` only)
+`sol` / `bsc` / `base` / `eth` (kline / trending only; trenches: `sol` / `bsc` / `base`; signal: `sol` / `bsc` only)
 
 ## Prerequisites
 
@@ -97,7 +97,7 @@ When a request returns `429`:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--address` | Yes | Token contract address |
 | `--resolution` | Yes | Candlestick resolution: `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
 | `--from` | No | Start time (Unix seconds) |
@@ -140,13 +140,13 @@ The response is an object with a `list` array. Each element in `list` is one can
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` |
 | `--interval` | Required. `1m` / `5m` / `1h` / `6h` / `24h` (default `1h`) |
 | `--limit <n>` | Number of results (default 100, max 100) |
 | `--order-by <field>` | Sort field: `default` / `swaps` / `marketcap` / `history_highest_market_cap` / `liquidity` / `volume` / `holder_count` / `smart_degen_count` / `renowned_count` / `gas_fee` / `price` / `change1m` / `change5m` / `change1h` / `creation_timestamp` |
 | `--direction <asc\|desc>` | Sort direction (default `desc`) |
-| `--filter <tag...>` | Repeatable filter tags (chain-specific). **⚠️ SOL defaults: `renounced frozen`; BSC/Base defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — chain defaults always apply. **sol** tags: `renounced` / `frozen` / `burn` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `not_wash_trading` / `is_internal_market` / `is_out_market`. **evm** tags: `not_honeypot` / `verified` / `renounced` / `locked` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `is_internal_market` / `is_out_market` |
-| `--platform <name...>` | Repeatable platform filter (chain-specific). **sol**: `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`. **bsc**: `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `flap` / `clanker` / `lunafun` / `pool_uniswap` / `pool_pancake`. **base**: `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik` |
+| `--filter <tag...>` | Repeatable filter tags (chain-specific). **⚠️ SOL defaults: `renounced frozen`; BSC/Base/ETH defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — chain defaults always apply. **sol** tags: `renounced` / `frozen` / `burn` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `not_wash_trading` / `is_internal_market` / `is_out_market`. **evm** tags: `not_honeypot` / `verified` / `renounced` / `locked` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `is_internal_market` / `is_out_market` |
+| `--platform <name...>` | Repeatable platform filter (chain-specific). **sol**: `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`. **bsc**: `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `flap` / `clanker` / `lunafun` / `pool_uniswap` / `pool_pancake`. **base**: `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik`. **eth**: no platform filter (omit `--platform` for ETH) |
 
 ## Usage Examples
 
@@ -176,6 +176,14 @@ gmgn-cli market kline \
 # Raw output for further processing
 gmgn-cli market kline --chain sol --address <addr> \
   --resolution 5m --from <ts> --to <ts> --raw | jq '.[]'
+
+# ETH token kline — last 24h, 1h candles (macOS)
+gmgn-cli market kline \
+  --chain eth \
+  --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
+  --resolution 1h \
+  --from $(date -v-24H +%s) \
+  --to $(date +%s)
 ```
 
 ### Trending — General
@@ -246,6 +254,25 @@ gmgn-cli market trending \
   --platform fourmeme --platform fourmeme_agent --platform bn_fourmeme --platform four_xmode_agent \
   --filter not_honeypot --filter verified \
   --order-by volume --limit 20 --raw
+```
+
+### Trending — ETH (No Platform Filter)
+
+```bash
+# ETH 1h trending — all tokens, sorted by volume
+gmgn-cli market trending --chain eth --interval 1h --order-by volume --limit 20
+
+# ETH 1h trending — with safety filters
+gmgn-cli market trending \
+  --chain eth --interval 1h \
+  --filter not_honeypot --filter verified \
+  --order-by volume --limit 20 --raw
+
+# ETH 24h trending — sorted by smart money count
+gmgn-cli market trending \
+  --chain eth --interval 24h \
+  --filter not_honeypot --filter verified \
+  --order-by smart_degen_count --limit 20 --raw
 ```
 
 ### Trending — Base by Launchpad Platform

--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-portfolio
-description: Analyze any crypto wallet by address — holdings, realized/unrealized P&L, win rate, trading history, performance stats, specific token balance, and tokens created by a developer wallet (with ATH market cap and DEX graduation status) via GMGN API on Solana, BSC, or Base. Use when user asks about a wallet's holdings, P&L, win rate, what tokens a dev has launched, the highest ATH token a dev ever created, or wants a wallet report to decide whether to copy-trade or follow.
-argument-hint: "<info|holdings|activity|stats|token-balance|created-tokens> [--chain <sol|bsc|base>] [--wallet <wallet_address>]"
+description: Analyze any crypto wallet by address — holdings, realized/unrealized P&L, win rate, trading history, performance stats, specific token balance, and tokens created by a developer wallet (with ATH market cap and DEX graduation status) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks about a wallet's holdings, P&L, win rate, what tokens a dev has launched, the highest ATH token a dev ever created, or wants a wallet report to decide whether to copy-trade or follow.
+argument-hint: "<info|holdings|activity|stats|token-balance|created-tokens> [--chain <sol|bsc|base|eth>] [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli portfolio --help"
 ---
@@ -43,7 +43,7 @@ Use the `gmgn-cli` tool to query wallet portfolio data based on the user's reque
 
 ## Supported Chains
 
-`sol` / `bsc` / `base`
+`sol` / `bsc` / `base` / `eth` (info / holdings / activity / stats / token-balance); `sol` / `bsc` / `base` (created-tokens)
 
 ## Prerequisites
 
@@ -139,6 +139,16 @@ gmgn-cli portfolio created-tokens \
 # Only migrated tokens
 gmgn-cli portfolio created-tokens \
   --chain sol --wallet <wallet_address> --migrate-state migrated
+
+# ETH wallet holdings
+gmgn-cli portfolio holdings --chain eth --wallet <0x_wallet_address>
+
+# ETH wallet transaction activity
+gmgn-cli portfolio activity --chain eth --wallet <0x_wallet_address>
+
+# ETH token balance
+gmgn-cli portfolio token-balance \
+  --chain eth --wallet <0x_wallet_address> --token <0x_token_address>
 ```
 
 ## `portfolio created-tokens` Options

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmgn-swap
-description: "[FINANCIAL EXECUTION] Buy and sell meme coins and crypto tokens on Solana, BSC, or Base — single swap, multi-wallet batch trading, limit orders, stop loss, take profit, trailing stop loss, trailing take profit via GMGN API. Requires explicit user confirmation. Use when user asks to buy, sell, or swap a token, trade from multiple wallets, set a limit order, stop loss, take profit, or check order status."
+description: "[FINANCIAL EXECUTION] Buy and sell meme coins and crypto tokens on Solana, BSC, Base, or Ethereum — single swap, multi-wallet batch trading, limit orders, stop loss, take profit, trailing stop loss, trailing take profit via GMGN API. Requires explicit user confirmation. Use when user asks to buy, sell, or swap a token, trade from multiple wallets, set a limit order, stop loss, take profit, or check order status."
 argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>] | [order strategy list --chain <chain> --group-tag <LimitOrder|STMix>] | [order strategy create --chain <chain> --order-type limit_order --sub-order-type <buy_low|buy_high|stop_loss|take_profit> ...]"
 metadata:
   cliHelp: "gmgn-cli swap --help"
@@ -55,18 +55,18 @@ Use the `gmgn-cli` tool to submit a token swap or query an existing order. `GMGN
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` 
-
+`sol` / `bsc` / `base` / `eth`
 
 ## Chain Currencies
 
 Currency tokens are the base/native assets of each chain. They are used to buy other tokens or receive proceeds from selling. Knowing which tokens are currencies is critical for `--percent` usage (see Swap Parameters below).
 
-| Chain | Currency tokens |
-|-------|----------------|
-| `sol` | SOL (native, So11111111111111111111111111111111111111112), USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
-| `bsc` | BNB (native, 0x0000000000000000000000000000000000000000), USDC (`0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d`) |
+| Chain  | Currency tokens |
+| ------ | --------------- |
+| `sol`  | SOL (native, So11111111111111111111111111111111111111112), USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
+| `bsc`  | BNB (native, 0x0000000000000000000000000000000000000000), USDC (`0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d`) |
 | `base` | ETH (native, 0x0000000000000000000000000000000000000000), USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) |
+| `eth`  | ETH (native, 0x0000000000000000000000000000000000000000), USDC (`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`) |
 
 
 ## Prerequisites
@@ -219,9 +219,9 @@ gmgn-cli multi-swap \
 | `--tip-fee <amount>` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB). Required when using `--condition-orders` on SOL. |
 | `--auto-tip-fee` | No | Enable automatic tip fee. |
 | `--max-auto-fee <amount>` | No | Max automatic fee cap. |
-| `--gas-price <gwei>` | No | Gas price in gwei (BSC ≥ 0.05 / BASE/ETH ≥ 0.01). Required when using `--condition-orders` on BSC. |
-| `--max-fee-per-gas <amount>` | No | EIP-1559 max fee per gas (Base only). |
-| `--max-priority-fee-per-gas <amount>` | No | EIP-1559 max priority fee per gas (Base only). |
+| `--gas-price <gwei>` | No | Gas price in gwei (BSC: 0.05–10 / BASE: 0.01–10 / ETH: 2–20). Required when using `--condition-orders` on BSC. |
+| `--max-fee-per-gas <amount>` | No | EIP-1559 max fee per gas (Base / ETH). Defaults to `--gas-price` if omitted. |
+| `--max-priority-fee-per-gas <amount>` | No | EIP-1559 max priority fee per gas (Base / ETH). Defaults to `--gas-price` if omitted. |
 | `--condition-orders <json>` | No | JSON array of condition sub-orders (take-profit / stop-loss) attached to each successful wallet's swap. Same structure as `swap --condition-orders`. Strategy creation is best-effort per wallet. |
 | `--sell-ratio-type <type>` | No | Sell ratio base for `--condition-orders`: `buy_amount` (default) / `hold_amount`. |
 
@@ -273,7 +273,7 @@ gmgn-cli order get --chain sol --order-id <order_id>
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--input-token` | Yes | Input token contract address |
 | `--output-token` | Yes | Output token contract address |

--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-token
-description: Research any crypto or meme token by address — real-time price, market cap, liquidity, holder list, trader list, top Smart Money and KOL positions, security audit (honeypot, rug pull risk, dev wallet, renounced status), social links (Twitter/X, website) via GMGN API on Solana, BSC, or Base. Use when user asks about a token's price, safety, holders, traders, smart money exposure, or wants due diligence before buying.
-argument-hint: "<sub-command> --chain <sol|bsc|base> --address <token_address>"
+description: Research any crypto or meme token by address — real-time price, market cap, liquidity, holder list, trader list, top Smart Money and KOL positions, security audit (honeypot, rug pull risk, dev wallet, renounced status), social links (Twitter/X, website) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks about a token's price, safety, holders, traders, smart money exposure, or wants due diligence before buying.
+argument-hint: "<sub-command> --chain <sol|bsc|base|eth> --address <token_address>"
 metadata:
   cliHelp: "gmgn-cli token --help"
 ---
@@ -17,7 +17,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 ## Core Concepts
 
 - **Token address** — The on-chain contract address that uniquely identifies a token on its chain. Required for all token sub-commands. Format: base58 (SOL) or `0x...` hex (BSC/Base).
-- **Chain** — The blockchain network: `sol` = Solana, `bsc` = BNB Smart Chain, `base` = Base (Coinbase L2).
+- **Chain** — The blockchain network: `sol` = Solana, `bsc` = BNB Smart Chain, `base` = Base (Coinbase L2), `eth` = Ethereum mainnet.
 - **Market cap** — Not returned directly by `token info`. Calculate as `price × circulating_supply` (both are top-level fields in the response, already in human-readable units).
 - **Liquidity** — USD value of token reserves in the main trading pool. Low liquidity (< $10k) means high price impact / slippage when buying or selling.
 - **Holder** — A wallet that currently holds the token. `token holders` returns wallets ranked by current balance.
@@ -42,7 +42,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 
 ## Supported Chains
 
-`sol` / `bsc` / `base`
+`sol` / `bsc` / `base` / `eth`
 
 ## Prerequisites
 
@@ -88,7 +88,7 @@ When a request returns `429`:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--address` | Yes | Token contract address |
 | `--raw` | No | Output raw single-line JSON (for piping or further processing) |
 
@@ -96,7 +96,7 @@ When a request returns `429`:
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--chain` | Yes | — | `sol` / `bsc` / `base` |
+| `--chain` | Yes | — | `sol` / `bsc` / `base` / `eth` |
 | `--address` | Yes | — | Token contract address |
 | `--limit` | No | `20` | Number of results, max `100` |
 | `--order-by` | No | `amount_percentage` | Sort field — see table below |
@@ -447,6 +447,9 @@ gmgn-cli token info --chain bsc --address 0x2170Ed0880ac9A755fd29B2688956BD959F9
 # Get basic info for a Base token
 gmgn-cli token info --chain base --address 0x4200000000000000000000000000000000000006
 
+# Get basic info for an ETH token
+gmgn-cli token info --chain eth --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
 # Raw JSON output for downstream processing
 gmgn-cli token info --chain sol --address EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --raw
 ```
@@ -463,6 +466,9 @@ gmgn-cli token security --chain bsc --address 0x2170Ed0880ac9A755fd29B2688956BD9
 # Check a Base token for tax, rug ratio, and insider concentration
 gmgn-cli token security --chain base --address 0x4200000000000000000000000000000000000006
 
+# Check an ETH token for honeypot and contract risks
+gmgn-cli token security --chain eth --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
 # Raw output for parsing key fields (e.g. is_honeypot, buy_tax, rug_ratio)
 gmgn-cli token security --chain bsc --address 0x2170Ed0880ac9A755fd29B2688956BD959F933F8 --raw
 ```
@@ -475,6 +481,9 @@ gmgn-cli token pool --chain sol --address EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZw
 
 # Get pool info for a BSC token
 gmgn-cli token pool --chain bsc --address 0x2170Ed0880ac9A755fd29B2688956BD959F933F8
+
+# Get pool info for an ETH token
+gmgn-cli token pool --chain eth --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 ```
 
 ### `token holders` — Analyze Holder Distribution
@@ -510,6 +519,10 @@ gmgn-cli token holders --chain sol --address EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGG
 # BSC token holders — KOL wallets by profit
 gmgn-cli token holders --chain bsc --address 0x2170Ed0880ac9A755fd29B2688956BD959F933F8 \
   --tag renowned --order-by profit --direction desc --limit 50
+
+# ETH token holders — smart money by supply percentage
+gmgn-cli token holders --chain eth --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
+  --tag smart_degen --order-by amount_percentage --direction desc --limit 20
 
 # Raw output for downstream analysis
 gmgn-cli token holders --chain sol --address EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v \
@@ -558,6 +571,10 @@ gmgn-cli token traders --chain sol --address EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGG
 
 # BSC token traders by profit
 gmgn-cli token traders --chain bsc --address 0x2170Ed0880ac9A755fd29B2688956BD959F933F8 \
+  --tag smart_degen --order-by profit --direction desc --limit 50
+
+# ETH token traders by profit
+gmgn-cli token traders --chain eth --address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 \
   --tag smart_degen --order-by profit --direction desc --limit 50
 ```
 

--- a/skills/gmgn-track/SKILL.md
+++ b/skills/gmgn-track/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-track
-description: Get real-time crypto buy/sell activity from Smart Money wallets, KOL influencer wallets, and personally followed wallets via GMGN API — alpha signals, whale tracking, meme token copy-trading ideas on Solana, BSC, or Base. Use when user asks what smart money or KOLs are buying, wants whale alerts, on-chain alpha, or copy-trade signals. (For a specific wallet address, use gmgn-portfolio.)
-argument-hint: "<follow-wallet|kol|smartmoney> [--chain <sol|bsc|base>] [--wallet <wallet_address>]"
+description: Get real-time crypto buy/sell activity from Smart Money wallets, KOL influencer wallets, and personally followed wallets via GMGN API — alpha signals, whale tracking, meme token copy-trading ideas on Solana, BSC, Base, or Ethereum. Use when user asks what smart money or KOLs are buying, wants whale alerts, on-chain alpha, or copy-trade signals. (For a specific wallet address, use gmgn-portfolio.)
+argument-hint: "<follow-wallet|kol|smartmoney> [--chain <sol|bsc|base|eth>] [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli track --help"
 ---
@@ -55,7 +55,7 @@ Use the `gmgn-cli` tool to query on-chain tracking data based on the user's requ
 
 ## Supported Chains
 
-`sol` / `bsc` / `base`
+`sol` / `bsc` / `base` / `eth` (follow-wallet); `sol` / `bsc` / `base` (kol / smartmoney)
 
 ## Prerequisites
 
@@ -130,7 +130,7 @@ gmgn-cli track smartmoney --chain sol --side sell --limit 10 --raw
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` |
 | `--wallet <address>` | Filter by wallet address |
 | `--limit <n>` | Page size (1–100, default 10) |
 | `--side <side>` | Trade direction: `buy` / `sell` |

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -26,7 +26,7 @@ export function registerMarketCommands(program: Command): void {
   market
     .command("kline")
     .description("Get token K-line (candlestick) data")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
     .requiredOption("--resolution <resolution>", "Candlestick resolution: 1m / 5m / 15m / 1h / 4h / 1d")
     .option("--from <timestamp>", "Start time (Unix seconds)", parseInt)
@@ -51,7 +51,7 @@ export function registerMarketCommands(program: Command): void {
   market
     .command("trending")
     .description("Get trending token swap data")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--interval <interval>", "Time interval: 1m / 5m / 1h / 6h / 24h")
     .option("--limit <n>", "Number of results (default 100, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: default / volume / swaps / marketcap / holder_count / price / change1h / ... (see docs for full list)")

--- a/src/commands/portfolio.ts
+++ b/src/commands/portfolio.ts
@@ -10,7 +10,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("holdings")
     .description("Get wallet token holdings")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--limit <n>", "Page size (default 20, max 50)", parseInt, 20)
     .option("--cursor <cursor>", "Pagination cursor")
@@ -46,7 +46,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("activity")
     .description("Get wallet transaction activity")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--token <address>", "Filter by token contract address")
     .option("--limit <n>", "Page size", parseInt)
@@ -71,7 +71,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("stats")
     .description("Get wallet trading statistics (supports multiple wallets)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--wallet <address...>", "Wallet address(es), repeatable")
     .option("--period <period>", "Stats period: 7d / 30d", "7d")
     .option("--raw", "Output raw JSON")
@@ -96,7 +96,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("token-balance")
     .description("Get wallet token balance for a single token")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--wallet <address>", "Wallet address")
     .requiredOption("--token <address>", "Token contract address")
     .option("--raw", "Output raw JSON")

--- a/src/commands/swap.ts
+++ b/src/commands/swap.ts
@@ -8,7 +8,7 @@ export function registerSwapCommands(program: Command): void {
   program
     .command("swap")
     .description("Submit a token swap")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth ")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -76,7 +76,7 @@ export function registerSwapCommands(program: Command): void {
   order
     .command("quote")
     .description("Get a swap quote without submitting a transaction (requires critical auth)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base (requires GMGN_PRIVATE_KEY)")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth (requires GMGN_PRIVATE_KEY)")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -10,7 +10,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("info")
     .description("Get token basic information and realtime price")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -24,7 +24,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("security")
     .description("Get token security metrics")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -38,7 +38,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("pool")
     .description("Get token liquidity pool information")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -52,7 +52,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("holders")
     .description("Get top token holders")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
     .option("--limit <n>", "Number of results (default 20, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: amount_percentage / profit / unrealized_profit / buy_volume_cur / sell_volume_cur", "amount_percentage")
@@ -75,7 +75,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("traders")
     .description("Get top token traders")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
     .option("--limit <n>", "Number of results (default 20, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: amount_percentage / profit / unrealized_profit / buy_volume_cur / sell_volume_cur", "amount_percentage")

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -10,7 +10,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-wallet")
     .description("Get follow-wallet trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .option("--wallet <address>", "Filter by wallet address")
     .option("--limit <n>", "Page size (1–100, default 10)", parseInt)
     .option("--side <side>", "Trade direction filter: buy / sell")


### PR DESCRIPTION
Add ETH chain support to all P0 commands across CLI and SKILL.md docs:

Commands with ETH support added:
- token info/security/pool/holders/traders
- market kline/trending
- portfolio info/holdings/activity/stats/token-balance
- track follow-wallet
- swap, order quote/get

P1/P2 commands remain sol/bsc/base only:
- track kol/smartmoney (P1)
- multi-swap, order strategy create/list/cancel (P1)
- portfolio created-tokens (P2)

Also adds ETH chain currencies, explorer links, and gas price bounds to gmgn-swap SKILL.md.