### PR TITLE
fix(swap): add critical warning to Chain Currencies table to prevent address guessing

### DIFF
--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -61,12 +61,14 @@ Use the `gmgn-cli` tool to submit a token swap or query an existing order. `GMGN
 
 Currency tokens are the base/native assets of each chain. They are used to buy other tokens or receive proceeds from selling. Knowing which tokens are currencies is critical for `--percent` usage (see Swap Parameters below).
 
+> ⚠️ **CRITICAL: Always copy currency addresses from this table — NEVER rely on memory or training data.** A wrong address (e.g. `So11111111111111111111111111111111111111111` instead of `So11111111111111111111111111111111111111112`) will cause silent failures or `jupiter has no route` errors with no clear indication of what went wrong.
+
 | Chain  | Currency tokens |
 | ------ | --------------- |
-| `sol`  | SOL (native, So11111111111111111111111111111111111111112), USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
-| `bsc`  | BNB (native, 0x0000000000000000000000000000000000000000), USDC (`0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d`) |
-| `base` | ETH (native, 0x0000000000000000000000000000000000000000), USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) |
-| `eth`  | ETH (native, 0x0000000000000000000000000000000000000000) |
+| `sol`  | SOL (native, `So11111111111111111111111111111111111111112`), USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
+| `bsc`  | BNB (native, `0x0000000000000000000000000000000000000000`), USDC (`0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d`) |
+| `base` | ETH (native, `0x0000000000000000000000000000000000000000`), USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) |
+| `eth`  | ETH (native, `0x0000000000000000000000000000000000000000`) |
 
 
 ## Prerequisites


### PR DESCRIPTION
## Problem

AI models may use incorrect currency token addresses from training data instead of looking them up in the skill documentation. For example, using `So11111111111111111111111111111111111111111` (ends in `1`) instead of the correct `So11111111111111111111111111111111111111112` (ends in `2`) for SOL native mint. This causes a misleading `GetSwapRouteErr: jupiter has no route` error with no clear indication that the address itself is wrong.

The existing instruction "never guess them" in Core Concepts is easy to overlook when constructing commands.

## Changes

- Added a `⚠️ CRITICAL` warning directly above the Chain Currencies table as a point-of-use reminder to always copy addresses from the table
- Wrapped all currency addresses in backticks for better readability and to distinguish them visually

## Why this matters

The error `jupiter has no route` is misleading — it looks like a liquidity or routing issue, not an address error. Without a prominent warning at the table itself, AI models may silently use wrong addresses and waste multiple retries debugging the wrong problem.