### PR TITLE
fix(trenches): fix apiFieldToCliKey for numeric suffix flags (--min/max-volume-24h etc.)

### DIFF
--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -290,13 +290,14 @@ const TRENCHES_FILTER_PRESETS: Record<string, Record<string, number | string>> =
 };
 
 // Convert API snake_case field to Commander.js opts key
-// Commander.js camelCase: only converts -[a-z] patterns, digits stay as-is
-// e.g. min_volume_24h → min-volume-24h → minVolume-24h (digit prefix -24 is NOT converted)
-// e.g. min_smart_degen_count → min-smart-degen-count → minSmartDegenCount (all letters, converts fully)
+// Commander.js camelCase: converts -[a-z] to uppercase, and removes hyphen before digits
+// e.g. min_volume_24h → min-volume-24h → minVolume-24h → minVolume24h
+// e.g. min_smart_degen_count → min-smart-degen-count → minSmartDegenCount
 function apiFieldToCliKey(apiField: string): string {
   return apiField
     .replace(/_/g, '-')
-    .replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+    .replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
+    .replace(/-(\d)/g, '$1');
 }
 
 // Client-side sort helpers (API does not support server-side sort for trenches)


### PR DESCRIPTION
Closes #118

## Summary

- **Bug**: `--min-volume-24h`, `--max-volume-24h` and all other `_24h`-suffixed filter flags were silently ignored
- **Root cause**: `apiFieldToCliKey()` produced `minVolume-24h` but Commander.js converts `--min-volume-24h` to `minVolume24h` — the hyphen before digits is removed, not kept. The opts lookup always returned `undefined`, so the filter was never added to the API request body.
- **Fix**: Add `.replace(/-(\d)/g, '$1')` to strip hyphens before digit sequences, matching Commander.js behavior exactly.

## Affected flags (all now fixed)

`--min-volume-24h` / `--max-volume-24h`, `--min-net-buy-24h` / `--max-net-buy-24h`, `--min-swaps-24h` / `--max-swaps-24h`, `--min-buys-24h` / `--max-buys-24h`, `--min-sells-24h` / `--max-sells-24h`

## Test plan

- [x] Local build passes (`npm run build`)
- [x] `gmgn-cli market trenches --chain sol --min-volume-24h 10000 --type completed` — all returned tokens have `volume_24h >= 10000` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)