### PR TITLE
docs(token): move native_transfer to Shared Funding section with updated description

### DIFF
--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -418,13 +418,18 @@ The response is an object with a `list` array. Each item in `list` represents on
 | `maker_token_tags` | Token-specific behavior tags for this wallet (e.g. `["bundler"]`, `["paper_hands"]`, `["top_holder"]`) |
 | `created_at` | Wallet creation timestamp (Unix seconds); `0` if unknown |
 
+**Shared Funding**
+
+| Field | Description |
+|-------|-------------|
+| `native_transfer` | First native token (SOL/BNB/ETH) transfer into this wallet — indicates the original funding source; wallets sharing the same `native_transfer.address` are likely funded from a common origin (coordinated wallets / same operator) |
+
 **Last Transaction Records**
 
 Each of the following is an object with `name`, `address`, `timestamp`, `tx_hash`, `type`:
 
 | Field | Description |
 |-------|-------------|
-| `native_transfer` | Most recent native token (SOL/BNB/ETH) transfer associated with this wallet |
 | `token_transfer` | Most recent token transfer (buy or sell) |
 | `token_transfer_in` | Most recent inbound token transfer |
 | `token_transfer_out` | Most recent outbound token transfer |


### PR DESCRIPTION
## Summary

- `native_transfer` records the **first** native token transfer into a wallet (funding source), not the most recent transaction
- Moved it out of **Last Transaction Records** into a new dedicated **Shared Funding** section above it
- Updated description: wallets sharing the same `native_transfer.address` are likely funded from a common origin (coordinated wallets / same operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)