### PR TITLE
fix(gmgn-token): correct fee_distribution usage hint and volume fields note

### DIFF
--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -288,7 +288,7 @@ The response has five nested objects: `pool`, `dev`, `link`, `stat`, `wallet_tag
 | `price.swaps_{window}` | Total swap count for the window |
 | `price.hot_level` | Heat level integer |
 
-**`fee_distribution` Object** — Launchpad fee-sharing config (optional; present for `pump` / `bankr` tokens)
+**`fee_distribution` Object** — Launchpad fee-sharing config (optional; present for `pump` / `bankr` tokens). Use `token info` to check fee distribution, creator reward claim status (`has_claimed_fee`), and royalty allocation for pump/bankr tokens.
 
 | Field | Description |
 |-------|-------------|
@@ -724,7 +724,7 @@ Show top rows only. Highlight wallets tagged `kol`, `smart_degen`, or flagged `b
 ## Notes
 
 - **Market cap is not returned directly** — calculate it as `price.price × circulating_supply` (`price` is now a nested object; use `price.price` for the current USD price string, and `circulating_supply` is a top-level field already in human-readable token units). Example: `price.price="3.11"` × `circulating_supply=999999151` ≈ $3.11B market cap.
-- **Trading volume (1h, 24h, etc.) is not included in `token info`** — to get volume or OHLCV data, use the `gmgn-market` skill and query K-line data: `gmgn-cli market kline --chain <chain> --address <token_address> --resolution <1m|5m|15m|1h|4h|1d>`. See the `gmgn-market` SKILL.md for full details.
+- **Trading volume and swap counts by window are available in `token info`** via the `price` object: `volume_{window}`, `buy_volume_{window}`, `sell_volume_{window}`, `buys_{window}`, `sells_{window}`, `swaps_{window}` (windows: `1m`, `5m`, `1h`, `6h`, `24h`). For OHLCV candlestick data, use `gmgn-market kline`.
 - All token commands use exist auth (API Key only, no signature required)
 - Use `--raw` to get single-line JSON for further processing
 - `--tag` applies to both `holders` and `traders` and filters to only wallets with that tag — if few results are returned, try the other tag value


### PR DESCRIPTION
## Summary

- **`fee_distribution` usage hint**: Added a sentence clarifying that `token info` is the command to use when querying fee distribution, creator reward claim status (`has_claimed_fee`), and royalty allocation for `pump`/`bankr` tokens.

- **Incorrect Note corrected**: The previous Note stated *"Trading volume (1h, 24h, etc.) is not included in `token info`"* — this is wrong. The `price` object in the `token info` response includes `volume_{window}`, `buy_volume_{window}`, `sell_volume_{window}`, `buys_{window}`, `sells_{window}`, and `swaps_{window}` for windows `1m`, `5m`, `1h`, `6h`, `24h`. The old note would cause agents to incorrectly redirect to `gmgn-market kline` for simple volume/swap count queries that `token info` already answers.

## Test plan

- [x] Agent asked "查这个币的领取信息" → correctly calls `token info` and reads `fee_distribution.platform_data.list[].has_claimed_fee`
- [x] Agent asked "查这个币最近5分钟的交易数和成交额" → correctly reads `price.buys_5m`, `price.sells_5m`, `price.volume_5m` from `token info` instead of redirecting to `market kline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)