### PR TITLE
docs: clarify price/price_usd in portfolio activity and check-price unit in strategy create

### DIFF
--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -233,7 +233,7 @@ The response has a `activities` array and a `next` cursor field for pagination.
 | `token.symbol` | Token ticker |
 | `token_amount` | Token quantity in this transaction |
 | `cost_usd` | USD value of this transaction |
-| `price` | Token price denominated in the quote token of the trading pair at time of transaction (e.g. SOL or USDC) |
+| `price` | Token price denominated in the quote token of the trading pair at time of transaction |
 | `price_usd` | Token price in USD at time of transaction |
 | `timestamp` | Unix timestamp of the transaction |
 | `next` | Pagination cursor — pass to `--cursor` to fetch the next page |

--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -233,7 +233,7 @@ The response has a `activities` array and a `next` cursor field for pagination.
 | `token.symbol` | Token ticker |
 | `token_amount` | Token quantity in this transaction |
 | `cost_usd` | USD value of this transaction |
-| `price` | Token price denominated in the quote token at time of transaction (e.g. price in SOL on Solana) |
+| `price` | Token price denominated in the quote token of the trading pair at time of transaction (e.g. SOL or USDC) |
 | `price_usd` | Token price in USD at time of transaction |
 | `timestamp` | Unix timestamp of the transaction |
 | `next` | Pagination cursor — pass to `--cursor` to fetch the next page |

--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -233,7 +233,8 @@ The response has a `activities` array and a `next` cursor field for pagination.
 | `token.symbol` | Token ticker |
 | `token_amount` | Token quantity in this transaction |
 | `cost_usd` | USD value of this transaction |
-| `price` | Token price in USD at time of transaction |
+| `price` | Token price denominated in the quote token at time of transaction (e.g. price in SOL on Solana) |
+| `price_usd` | Token price in USD at time of transaction |
 | `timestamp` | Unix timestamp of the transaction |
 | `next` | Pagination cursor — pass to `--cursor` to fetch the next page |
 

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -544,7 +544,7 @@ gmgn-cli order strategy create \
 | `--quote-token` | Yes | all | Quote token contract address |
 | `--order-type` | Yes | all | Order type: `limit_order` |
 | `--sub-order-type` | Yes | all | Sub-order type: `buy_low` / `buy_high` / `stop_loss` / `take_profit` |
-| `--check-price` | Yes | all | Trigger check price |
+| `--check-price` | Yes | all | Trigger price in USD — the order fires when the token's USD price crosses this value |
 | `--amount-in` | No* | all | Input amount (smallest unit). Mutually exclusive with `--amount-in-percent` |
 | `--amount-in-percent` | No* | all | Input as percentage (e.g. `50` = 50%). Mutually exclusive with `--amount-in` |
 | `--limit-price-mode` | No | all | `exact` / `slippage` (default: `slippage`) |


### PR DESCRIPTION
## Changes

### 1. `gmgn-portfolio` — `portfolio activity` response fields
- Fixed: `price` was incorrectly described as "Token price in USD". It is actually the token price denominated in the **quote token** (e.g. SOL on Solana).
- Added: `price_usd` field — the token price in USD at time of transaction.

### 2. `gmgn-swap` — `order strategy create` parameters
- Clarified: `--check-price` now explicitly states it is in **USD**, and explains when the order fires.

## Why
Without these clarifications, users may pass the wrong value to `--check-price` (e.g. token-denominated price instead of USD), and may misread `price` in activity records as USD when it is quote-token-denominated.