### PR TITLE
docs(swap): add rate limit weights for strategy and multi_swap routes

### DIFF
--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -88,6 +88,9 @@ All swap-related routes used by this skill go through GMGN's leaky-bucket limite
 | `multi-swap` | `POST /v1/trade/multi_swap` | 5 |
 | `order quote` | `GET /v1/trade/quote` | 2 |
 | `order get` | `GET /v1/trade/query_order` | 1 |
+| `order strategy create` | `POST /v1/trade/strategy/create` | 5 |
+| `order strategy cancel` | `POST /v1/trade/strategy/cancel` | 2 |
+| `order strategy list` | `GET /v1/trade/strategy/orders` | 1 |
 | `gas-price` | `GET /v1/trade/gas_price` | 1 |
 
 When a request returns `429`:


### PR DESCRIPTION
- order strategy create: POST /v1/trade/strategy/create — weight 5
- order strategy cancel: POST /v1/trade/strategy/cancel — weight 2
- order strategy list:   GET  /v1/trade/strategy/orders — weight 1
- multi-swap already listed; confirms weight 5 (same as swap)