### PR TITLE
feat(cooking): update SKILL.md and cli-usage with validated DEX/raised_token constraints

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -738,8 +738,8 @@ gmgn-cli cooking create \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `ton` |
-| `--dex` | Yes | Launchpad: `pump` / `raydium` / `pancakeswap` / `flap` / `fourmeme` / `bonk` / `bags` / ... |
+| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--dex` | Yes | Launchpad per chain — see table below |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--name` | Yes | Token name |
 | `--symbol` | Yes | Token symbol |
@@ -751,10 +751,18 @@ gmgn-cli cooking create \
 | `--telegram` | No | Telegram link |
 | `--slippage` | No | Slippage tolerance, e.g. `0.01` = 1% |
 | `--auto-slippage` | No | Enable automatic slippage |
-| `--priority-fee` | No | Priority fee in SOL (SOL only) |
-| `--tip-fee` | No | Tip fee |
-| `--gas-price` | No | Gas price in wei (EVM chains) |
-| `--anti-mev` | No | Enable anti-MEV protection |
+| `--priority-fee` | No | Priority fee in SOL (**SOL only**, ≥ 0.0001 SOL) |
+| `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on BASE) |
+| `--gas-price` | No | Gas price in wei (BSC / BASE) |
+| `--anti-mev` | No | Enable anti-MEV protection (**SOL only**) |
+
+**Supported chains and DEX values:**
+
+| Chain  | `--dex`              | Raise token (API `raised_token` field) |
+| ------ | -------------------- | -------------------------------------- |
+| `sol`  | `pump`, `bonk`, `bags` | `pump`: `""` (SOL) or `"USDC"`; `bonk`: `""` (SOL) or `"USD1"`; `bags`: `""` only |
+| `bsc`  | `fourmeme`, `flap`   | `fourmeme`: `""` (BNB), `"USD1"`, `"USDT"`; `flap`: `""` only |
+| `base` | `klik`, `clanker`    | `""` only |
 
 **Response fields (data):**
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -730,9 +730,22 @@ gmgn-cli cooking create \
   --buy-amt <amount> \
   [--image <base64> | --image-url <url>] \
   [--slippage <n> | --auto-slippage] \
+  [--description <text>] \
   [--website <url>] [--twitter <url>] [--telegram <url>] \
   [--priority-fee <sol>] [--tip-fee <amount>] [--gas-price <amount>] \
-  [--anti-mev] \
+  [--max-fee-per-gas <amount>] [--max-priority-fee-per-gas <amount>] \
+  [--anti-mev] [--anti-mev-mode <normal|secure>] \
+  [--raised-token <symbol>] \
+  [--dev-wallet-bps <n>] [--dev-gas <amount>] [--dev-priority <amount>] [--dev-tip <amount>] \
+  [--approve-vision <v1|v2>] [--source <source>] \
+  [--is-mayhem] [--is-cashback] [--is-revoke-fee-auth] \
+  [--is-agent] [--agent-bps <n>] \
+  [--pump-fee-share-list <json>] \
+  [--flap-rate-conf <json>] \
+  [--fourmeme-rate-conf <json>] \
+  [--bags-fee-share-list <json>] \
+  [--bonk-model <model>] \
+  [--buy-wallets <json>] [--snip-buy-wallets <json>] [--interval-seconds <n>] \
   [--raw]
 ```
 
@@ -746,15 +759,39 @@ gmgn-cli cooking create \
 | `--buy-amt` | Yes | Initial buy amount in native token (e.g. `0.01` SOL) |
 | `--image` | No* | Token logo as base64-encoded data (max 2MB decoded); required unless `--image-url` is used |
 | `--image-url` | No* | Token logo URL; required unless `--image` is used |
+| `--slippage` | No* | Slippage tolerance, e.g. `0.01` = 1%; required unless `--auto-slippage` is used |
+| `--auto-slippage` | No* | Enable automatic slippage; required unless `--slippage` is used |
+| `--description` | No | Token description / project pitch |
 | `--website` | No | Website URL |
 | `--twitter` | No | Twitter link |
 | `--telegram` | No | Telegram link |
-| `--slippage` | No | Slippage tolerance, e.g. `0.01` = 1% |
-| `--auto-slippage` | No | Enable automatic slippage |
 | `--priority-fee` | No | Priority fee in SOL (**SOL only**, ≥ 0.0001 SOL) |
 | `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on BASE) |
-| `--gas-price` | No | Gas price in wei (BSC / BASE) |
+| `--gas-price` | No | Gas price in wei (**EVM only**) |
+| `--max-fee-per-gas` | No | Max fee per gas in wei (**EVM only**) |
+| `--max-priority-fee-per-gas` | No | Max priority fee per gas in wei (**EVM only**) |
 | `--anti-mev` | No | Enable anti-MEV protection (**SOL only**) |
+| `--anti-mev-mode` | No | Anti-MEV mode: `normal` / `secure` (**SOL only**) |
+| `--raised-token` | No | Raise token symbol: `pump`→`USDC`; `bonk`→`USD1`; `fourmeme`→`USDT`/`USD1`; omit for native |
+| `--dev-wallet-bps` | No | Dev wallet fee share in basis points (100 = 1%) |
+| `--dev-gas` | No | Dev gas amount |
+| `--dev-priority` | No | Dev priority fee |
+| `--dev-tip` | No | Dev tip fee |
+| `--approve-vision` | No | Approve vision version: `v1` / `v2` (default: `v2`) |
+| `--source` | No | Traffic source identifier |
+| `--is-mayhem` | No | Enable Mayhem mode (**Pump.fun only**) |
+| `--is-cashback` | No | Enable Cashback (**Pump.fun only**) |
+| `--is-revoke-fee-auth` | No | Revoke fee authority (**Pump.fun only**) |
+| `--is-agent` | No | Enable Agent mode (**Pump.fun only**) |
+| `--agent-bps` | No | Agent fee in basis points (**Pump.fun only**) |
+| `--pump-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
+| `--flap-rate-conf` | No | Rate config as JSON object (**Flap only**) |
+| `--fourmeme-rate-conf` | No | Rate config as JSON object (**FourMeme only**) |
+| `--bags-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**BAGS only**) |
+| `--bonk-model` | No | Bonk model identifier (**bonk DEX only**) |
+| `--buy-wallets` | No | Multi-wallet buy config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--snip-buy-wallets` | No | Snipe-buy wallet config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--interval-seconds` | No | Interval between multi-wallet buys in seconds |
 
 **Supported chains and DEX values:**
 

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -135,12 +135,12 @@ gmgn-cli cooking stats [--raw]
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--name` | Yes | Token full name (e.g. `Doge Killer`) |
 | `--symbol` | Yes | Token ticker symbol (e.g. `DOGEK`) |
-| `--description` | No | Token description / project pitch |
 | `--buy-amt` | Yes | Initial buy amount in **human-readable native token units** (e.g. `0.01` = 0.01 SOL). This is NOT in smallest unit. |
 | `--image` | No* | Token logo as **base64-encoded** data (max 2MB decoded). Mutually exclusive with `--image-url`. One of the two is required. |
 | `--image-url` | No* | Token logo as a publicly accessible URL. Mutually exclusive with `--image`. One of the two is required. |
 | `--slippage` | No* | Slippage tolerance, e.g. `0.01` = 1%. **Mutually exclusive with `--auto-slippage`** — provide one or the other. |
 | `--auto-slippage` | No* | Enable automatic slippage. **Mutually exclusive with `--slippage`.** |
+| `--description` | No | Token description / project pitch |
 | `--website` | No | Project website URL |
 | `--twitter` | No | Twitter / X URL |
 | `--telegram` | No | Telegram group URL |
@@ -148,8 +148,149 @@ gmgn-cli cooking stats [--raw]
 | `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on BASE) |
 | `--gas-price` | No | Gas price in wei (EVM chains: BSC / BASE) |
 | `--anti-mev` | No | Enable anti-MEV protection (**SOL only**; rejected on BSC / BASE) |
+| `--anti-mev-mode` | No | Anti-MEV mode: `normal` / `secure` (**SOL only**) |
+| `--raised-token` | No | Raise token symbol. `pump`: `USDC`; `bonk`: `USD1`; `fourmeme`: `USDT` / `USD1`; omit or `""` for native |
+| `--dev-wallet-bps` | No | Dev wallet fee share in basis points (100 = 1%) |
+| `--max-fee-per-gas` | No | Max fee per gas in wei (**EVM only**) |
+| `--max-priority-fee-per-gas` | No | Max priority fee per gas in wei (**EVM only**) |
+| `--dev-gas` | No | Dev gas amount |
+| `--dev-priority` | No | Dev priority fee |
+| `--dev-tip` | No | Dev tip fee |
+| `--approve-vision` | No | Approve vision version: `v1` / `v2` (default: `v2`) |
+| `--source` | No | Traffic source identifier |
+| `--is-mayhem` | No | Enable Mayhem mode (**Pump.fun only**) |
+| `--is-cashback` | No | Enable Cashback (**Pump.fun only**) |
+| `--is-revoke-fee-auth` | No | Revoke fee authority (**Pump.fun only**) |
+| `--is-agent` | No | Enable Agent mode (**Pump.fun only**) |
+| `--agent-bps` | No | Agent fee in basis points (**Pump.fun only**) |
+| `--pump-fee-share-list` | No | Pump.fun fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
+| `--flap-rate-conf` | No | Flap rate config as JSON object (**Flap only**) |
+| `--fourmeme-rate-conf` | No | FourMeme rate config as JSON object (**FourMeme only**) |
+| `--bags-fee-share-list` | No | BAGS fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**BAGS only**) |
+| `--bonk-model` | No | Bonk model identifier (**bonk DEX only**) |
+| `--buy-wallets` | No | Multi-wallet buy config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--snip-buy-wallets` | No | Snipe-buy wallet config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--interval-seconds` | No | Interval between multi-wallet buys in seconds |
 
 \* `--image` or `--image-url`: provide exactly one. `--slippage` or `--auto-slippage`: provide exactly one.
+
+## Advanced API Fields
+
+The structured flags (`--pump-fee-share-list`, `--bags-fee-share-list`, `--flap-rate-conf`, `--fourmeme-rate-conf`, `--buy-wallets`, `--snip-buy-wallets`) each accept a **JSON string**. This section documents the exact JSON schema for each. It also lists fields that have **no CLI flag** and require the raw `create_token` payload — use those only when the CLI flag cannot cover the need.
+
+**Basis-points rule:** any field named `*_bps` / `basic_points` is in basis points (`100` = 1%). Where a section says the shares must sum, all entries must add up to exactly **10000** (FourMeme uses **100** instead — see below).
+
+**Always talk to the user in percentages, never basis points.** Convert to bps yourself when building the JSON:
+
+| User says | `*_bps` field (×100) | FourMeme `*_rate` field (×1) |
+|---|---|---|
+| `5%` | `500` | `5` |
+| `50%` | `5000` | `50` |
+| `100%` | `10000` | `100` |
+
+Never set a fee-share split without the user's explicit instruction — it permanently routes token revenue to the listed accounts.
+
+### Pump.fun (`--dex pump`)
+
+> `is_mayhem`, `is_cashback`, `is_revoke_fee_auth`, `is_agent`, `agent_bps` use their matching CLI flags. `pump_fee_share_list` is passed via `--pump-fee-share-list`.
+
+| Field | CLI flag | Description |
+|---|---|---|
+| `pump_fee_share_list` | `--pump-fee-share-list <json>` | Fee-share list — see JSON schema below |
+| `is_buy_back` | *(no flag — raw payload only)* | Enable Agent Auto Buyback |
+
+**JSON schema for `--pump-fee-share-list`** — array of objects:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `provider` | string | Yes | `twitter` / `github` / `wallet` |
+| `username` | string | Yes | Username for `twitter`/`github`; a SOL address when `wallet` |
+| `basic_points` | int | Yes | Share in bps — all entries must sum to **10000** |
+
+Example: `--pump-fee-share-list '[{"provider":"twitter","username":"handle","basic_points":10000}]'`
+
+### Bonk (`--dex bonk`)
+
+`dev_wallet_bps` → `--dev-wallet-bps`, `bonk_model` → `--bonk-model`. No additional structured fields.
+
+### BAGS (`--dex bags`)
+
+`dev_wallet_bps` → `--dev-wallet-bps`. `bags_fee_share_list` is passed via `--bags-fee-share-list`.
+
+**JSON schema for `--bags-fee-share-list`** — array of objects:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `provider` | string | Yes | `twitter` / `solana` / `kick` / `github` |
+| `username` | string | Yes | Platform username |
+| `basic_points` | int | Yes | Share in bps — combined with `dev_wallet_bps`, all must sum to **10000** |
+
+### Flap (`--dex flap`)
+
+`flap_rate_conf` is passed via `--flap-rate-conf`.
+
+**JSON schema for `--flap-rate-conf`** — single object:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `beneficiary` | string | Yes | Fee recipient address |
+| `tax_rate` | int | Yes | Tax rate in bps, e.g. 5% → `500` |
+| `mkt_bps` | int | Yes | Marketing / donation fund share |
+| `deflation_bps` | int | Yes | Burn (supply-reduction) share |
+| `dividend_bps` | int | Yes | Dividend (holder-reward) share |
+| `lp_bps` | int | Yes | Liquidity share |
+| `minimum_share_balance` | int | Yes | Min holding to qualify for dividends — minimum **10000** tokens |
+| `recipient_type` | string | Yes | `split` (proportional) / `gift` |
+| `twitter_account` | string | Yes | Twitter username |
+| `split_conf` | array | Yes | Split list — see below |
+
+`split_conf` entries: `{ "recipient": "<address>", "split_bps": <n> }` — all `split_bps` must sum to **10000**.
+
+> When `tax_rate > 0`: `mkt_bps + deflation_bps + dividend_bps + lp_bps` must sum to **10000**. When `lp_bps > 0`: `minimum_share_balance` must be > 0.
+
+### FourMeme (`--dex fourmeme`)
+
+`fourmeme_rate_conf` is passed via `--fourmeme-rate-conf`. The remaining fields below have **no CLI flag** and require the raw payload.
+
+| Field | CLI flag | Description |
+|---|---|---|
+| `fourmeme_rate_conf` | `--fourmeme-rate-conf <json>` | Fee-share config — see JSON schema below |
+| `fourmeme_user_login_sign` | *(no flag)* | FourMeme user login signature |
+| `is_approve_allowance` | *(no flag)* | Pass `true` on retry to skip the allowance step |
+| `is_raised_swap` | *(no flag)* | Pass `true` on a multi-quote retry when raise-token swap already completed |
+
+**JSON schema for `--fourmeme-rate-conf`** — single object:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fee_plan` | bool | No | Enable the fee plan |
+| `recipient_address` | string | Yes | Fee recipient address |
+| `fee_rate` | int | Yes | Fee rate, e.g. 5% → `5` (whole percent, not bps) |
+| `burn_rate` | int | Yes | Burn share |
+| `divide_rate` | int | Yes | Dividend share |
+| `liquidity_rate` | int | Yes | Liquidity share |
+| `recipient_rate` | int | Yes | Recipient share |
+| `min_sharing` | int | Yes | Minimum sharing threshold |
+
+> When `fee_rate > 0`: `burn_rate + divide_rate + liquidity_rate + recipient_rate` must sum to **100**. When `recipient_rate > 0`: `min_sharing` must be > 0.
+
+## Auto-Sell Configuration
+
+`sell_configs` has **no CLI flag** and requires the raw `create_token` payload. It schedules conditional sell orders to execute automatically once the token launch succeeds. Omit entirely for a standard launch with no auto-sell.
+
+`sell_configs` is an array of `CookingSellConfig` objects:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `sell_type` | string | Yes | `delay_sell` / `limit_order` |
+| `delay_sec` | int64 | Conditional | Seconds after buy to trigger; required when `sell_type = delay_sell` |
+| `sell_ratio` | string | Yes | Fraction to sell — `"1"` = 100%, `"0.5"` = 50% |
+| `check_price` | string | Conditional | Market cap in USD to trigger sell; required when `sell_type = limit_order` |
+| `wallet_addresses` | []string | Yes | Wallets this strategy applies to |
+
+> - **`check_price` is total market cap in USD** — e.g. `"50000"` triggers at a $50,000 market cap.
+> - `wallet_addresses` may mix `from_address` and `buy_wallets` entries. The server creates `signal_cooking` for snipe wallets and `pending_sell` for main/bundle wallets automatically.
+> - A wallet can carry multiple strategies (e.g. delay-sell 50%, then limit-sell the rest); each applies independently.
 
 ## `cooking create` Response Fields
 
@@ -249,9 +390,14 @@ Initial Buy:  {--buy-amt} {native currency} (e.g. 0.01 SOL)
 Slippage:     {--slippage}% (or "auto")
 Image:        {--image-url or "base64 provided"}
 Social:       {twitter / telegram / website if provided}
+Modes:        {Mayhem / Cashback / Agent Auto Buyback if set, else "none"}
+Fee Share:    {recipient → % list if set, else "none"}
+Auto-Sell:    {sell_configs summary if set, else "none"}
 
 Reply "confirm" to deploy this token. This action is IRREVERSIBLE.
 ```
+
+Omit the Modes / Fee Share / Auto-Sell lines if none were configured — or show them as `none` — but if any **are** set, they MUST appear here so the user re-confirms them explicitly.
 
 ### Post-create Receipt
 
@@ -301,6 +447,8 @@ Show the options concisely:
 
 If the user is unsure, recommend: **Pump.fun (SOL)** or **FourMeme (BSC)**.
 
+The chosen platform determines which advanced options are available later in Step 7 (e.g. Mayhem/Agent on Pump.fun, fee-share splits on BAGS/Flap/FourMeme). Note the platform now; do not ask about advanced options yet.
+
 ### Step 2 — Token Name
 
 Ask: *"Token name?"*
@@ -339,9 +487,21 @@ Ask all optional fields together in one message:
 
 The user can reply with just the ones they have, or say "skip" / "none" to proceed.
 
-### Step 7 — Confirmation & Execute
+### Step 7 — Platform Modes, Fees & Auto-Sell (platform-dependent)
 
-Once all information is collected, present the pre-create confirmation summary (see Output Format section) and wait for the user to reply "confirm" before executing.
+After the basics are collected, ask **once** whether the user wants any advanced options for the platform they chose. Default everyone to a plain fair launch — only configure these when the user explicitly asks. Tailor the question to the selected platform; do not list options that don't apply to it.
+
+Ask: *"Want any advanced options, or launch with defaults? (reply 'defaults' to skip)"* — then offer the relevant subset:
+
+- **Pump.fun modes** — Mayhem (`--is-mayhem`), Cashback (`--is-cashback`), Agent (`--is-agent` + `--agent-bps`), Agent Auto Buyback (`is_buy_back` — raw payload only).
+- **Fee-share split** — Pump.fun (`--pump-fee-share-list`), BAGS (`--dev-wallet-bps` + `--bags-fee-share-list`), Bonk (`--dev-wallet-bps`), Flap (`--flap-rate-conf`), FourMeme (`--fourmeme-rate-conf`). See [Advanced API Fields](#advanced-api-fields) for JSON schemas. **Warn the user this permanently routes token revenue to the listed accounts.** Always ask the user for shares as percentages — convert to bps yourself. Shares must add up to 100%.
+- **Auto-sell** — `sell_configs` (raw payload only): delay-sell (sell a fraction N seconds after the buy) and/or limit-sell (sell once market cap hits a USD target). See [Auto-Sell Configuration](#auto-sell-configuration). Confirm the sell ratio and trigger before setting it.
+
+If the user says "defaults" / "skip" / "none", proceed with none of these set.
+
+### Step 8 — Confirmation & Execute
+
+Once all information is collected, present the pre-create confirmation summary (see Output Format section) and wait for the user to reply "confirm" before executing. If any advanced options from Step 7 were set, they MUST appear in the summary so the user re-confirms them explicitly.
 
 ---
 

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -48,17 +48,19 @@ Use the `gmgn-cli` tool to create a token on a launchpad platform or query token
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `ton`
+`sol` / `bsc` / `base`
 
 ## Supported Launchpads by Chain
 
-| Chain | `--dex` values |
-|-------|----------------|
-| `sol` | `pump` / `raydium` / `bonk` / `bags` / `memoo` / `letsbonk` / `bonkers` |
-| `bsc` | `pancakeswap` / `flap` / `fourmeme` |
-| `base` | `clanker` / `flaunch` / `baseapp` / `basememe` / `zora` / `virtuals_v2` |
+| Chain  | `--dex` values       | Raise token (`raised_token`, API-only field) |
+| ------ | -------------------- | -------------------------------------------- |
+| `sol`  | `pump`, `bonk`, `bags` | `pump`: `""` (SOL) or `"USDC"`; `bonk`: `""` (SOL) or `"USD1"`; `bags`: `""` (SOL only) |
+| `bsc`  | `fourmeme`, `flap`   | `fourmeme`: `""` (BNB), `"USD1"`, `"USDT"`; `flap`: `""` (BNB only) |
+| `base` | `klik`, `clanker`    | `""` only (quote token fixed to WETH) |
 
-When the user names a platform colloquially (e.g. "pump.fun", "four.meme", "PancakeSwap"), map it to the correct `--dex` identifier from this table before running the command.
+When the user names a platform colloquially (e.g. "pump.fun", "four.meme"), map it to the correct `--dex` identifier from this table before running the command.
+
+**Anti-MEV** (`--anti-mev`) is only supported on `sol`. Passing it on `bsc` or `base` will return a 400 error.
 
 ## Prerequisites
 
@@ -128,7 +130,7 @@ gmgn-cli cooking stats [--raw]
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | Chain: `sol` / `bsc` / `base` / `eth` / `ton` |
+| `--chain` | Yes | Chain: `sol` / `bsc` / `base` |
 | `--dex` | Yes | Launchpad platform identifier — see Supported Launchpads table. Never guess this value. |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--name` | Yes | Token full name (e.g. `Doge Killer`) |
@@ -142,10 +144,10 @@ gmgn-cli cooking stats [--raw]
 | `--website` | No | Project website URL |
 | `--twitter` | No | Twitter / X URL |
 | `--telegram` | No | Telegram group URL |
-| `--priority-fee` | No | Priority fee in SOL (SOL only, ≥ 0.0001 SOL) |
-| `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on ETH/BASE) |
-| `--gas-price` | No | Gas price in wei (EVM chains) |
-| `--anti-mev` | No | Enable anti-MEV protection |
+| `--priority-fee` | No | Priority fee in SOL (**SOL only**, ≥ 0.0001 SOL) |
+| `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on BASE) |
+| `--gas-price` | No | Gas price in wei (EVM chains: BSC / BASE) |
+| `--anti-mev` | No | Enable anti-MEV protection (**SOL only**; rejected on BSC / BASE) |
 
 \* `--image` or `--image-url`: provide exactly one. `--slippage` or `--auto-slippage`: provide exactly one.
 
@@ -287,21 +289,15 @@ Ask: *"Which chain and platform?"*
 
 Show the options concisely:
 
-| Chain | Platform | `--dex` |
-|-------|----------|---------|
-| Solana | Pump.fun | `pump` |
-| Solana | letsbonk | `letsbonk` |
-| Solana | Raydium | `raydium` |
-| Solana | BAGS | `bags` |
-| Solana | Memoo | `memoo` |
-| Solana | Bonkers | `bonkers` |
-| BSC | FourMeme | `fourmeme` |
-| BSC | PancakeSwap | `pancakeswap` |
-| BSC | Flap | `flap` |
-| Base | Clanker | `clanker` |
-| Base | Zora | `zora` |
-| Base | Flaunch | `flaunch` |
-| Base | Virtuals | `virtuals_v2` |
+| Chain  | Platform   | `--dex`    |
+| ------ | ---------- | ---------- |
+| Solana | Pump.fun   | `pump`     |
+| Solana | Bonk       | `bonk`     |
+| Solana | BAGS       | `bags`     |
+| BSC    | FourMeme   | `fourmeme` |
+| BSC    | Flap       | `flap`     |
+| Base   | Klik       | `klik`     |
+| Base   | Clanker    | `clanker`  |
 
 If the user is unsure, recommend: **Pump.fun (SOL)** or **FourMeme (BSC)**.
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -170,27 +170,113 @@ export interface TokenSignalGroup {
   max_create_or_open_ts?: string;
 }
 
+export interface PumpFeeShareInfo {
+  provider: string;
+  username: string;
+  basic_points: number;
+}
+
+export interface BAGSFeeShareInfo {
+  provider: string;
+  username: string;
+  basic_points: number;
+}
+
+export interface FlapRateConf {
+  tax_rate?: number;
+  mkt_bps?: number;
+  deflation_bps?: number;
+  dividend_bps?: number;
+  lp_bps?: number;
+  minimum_share_balance?: number;
+  recipient_type?: string;
+  beneficiary?: string;
+  twitter_account?: string;
+  split_conf?: Array<{ recipient: string; split_bps: number }>;
+}
+
+export interface FourmemeRateConf {
+  fee_plan?: boolean;
+  fee_rate?: number;
+  burn_rate?: number;
+  divide_rate?: number;
+  liquidity_rate?: number;
+  recipient_rate?: number;
+  recipient_address?: string;
+  min_sharing?: number;
+}
+
+export interface BuyWalletInfo {
+  from_address: string;
+  buy_amt: string;
+}
+
 export interface CreateTokenParams {
+  // Required
   chain: string;
   dex: string;
   from_address: string;
   name: string;
   symbol: string;
   buy_amt: string;
+
+  // Image (one required)
   image?: string;
   image_url?: string;
+
+  // Social
   website?: string;
   twitter?: string;
   telegram?: string;
+
+  // Transaction
   slippage?: number;
   auto_slippage?: boolean;
+
+  // Fees
   priority_fee?: string;
   tip_fee?: string;
   gas_price?: string;
   max_priority_fee_per_gas?: string;
   max_fee_per_gas?: string;
+
+  // Anti-MEV (SOL only)
   is_anti_mev?: boolean;
   anti_mev_mode?: string;
+
+  // Advanced
+  raised_token?: string;
+  dev_gas?: string;
+  dev_priority?: string;
+  dev_tip?: string;
+  approve_vision?: string;
+  source?: string;
+  dev_wallet_bps?: number;
+
+  // Pump.fun specific
+  is_mayhem?: boolean;
+  is_cashback?: boolean;
+  is_revoke_fee_auth?: boolean;
+  is_agent?: boolean;
+  agent_bps?: number;
+  pump_fee_share_list?: PumpFeeShareInfo[];
+
+  // Flap specific
+  flap_rate_conf?: FlapRateConf;
+
+  // FourMeme specific
+  fourmeme_rate_conf?: FourmemeRateConf;
+
+  // BAGS specific
+  bags_fee_share_list?: BAGSFeeShareInfo[];
+
+  // Bonk specific
+  bonk_model?: string;
+
+  // Multi-wallet buy
+  buy_wallets?: BuyWalletInfo[];
+  snip_buy_wallets?: BuyWalletInfo[];
+  interval_seconds?: number;
 }
 
 export class OpenApiClient {

--- a/src/commands/cooking.ts
+++ b/src/commands/cooking.ts
@@ -36,7 +36,37 @@ export function registerCookingCommands(program: Command): void {
     .option("--priority-fee <sol>", "Priority fee in SOL (SOL only)")
     .option("--tip-fee <amount>", "Tip fee")
     .option("--gas-price <amount>", "Gas price in wei (EVM chains)")
-    .option("--anti-mev", "Enable anti-MEV protection")
+    .option("--anti-mev", "Enable anti-MEV protection (SOL only)")
+    .option("--anti-mev-mode <mode>", "Anti-MEV mode: normal / secure (SOL only)")
+    .option("--raised-token <symbol>", "Raise token symbol: pump→USDC; bonk→USD1; fourmeme→USDT/USD1; leave empty for native")
+    .option("--description <text>", "Token description / project pitch")
+    .option("--dev-wallet-bps <n>", "Dev wallet fee in basis points (100 = 1%)", parseInt)
+    .option("--max-fee-per-gas <amount>", "Max fee per gas in wei (EVM only)")
+    .option("--max-priority-fee-per-gas <amount>", "Max priority fee per gas in wei (EVM only)")
+    .option("--dev-gas <amount>", "Dev gas amount")
+    .option("--dev-priority <amount>", "Dev priority fee")
+    .option("--dev-tip <amount>", "Dev tip fee")
+    .option("--approve-vision <version>", "Approve vision version: v1 / v2 (default: v2)")
+    .option("--source <source>", "Traffic source identifier")
+    // Pump.fun specific
+    .option("--is-mayhem", "Enable Mayhem mode (Pump.fun only)")
+    .option("--is-cashback", "Enable Cashback (Pump.fun only)")
+    .option("--is-revoke-fee-auth", "Revoke fee authority (Pump.fun only)")
+    .option("--is-agent", "Enable Agent mode (Pump.fun only)")
+    .option("--agent-bps <n>", "Agent fee in basis points (Pump.fun only)", parseInt)
+    .option("--pump-fee-share-list <json>", "Pump.fun fee share list as JSON array (Pump.fun only)")
+    // Flap specific
+    .option("--flap-rate-conf <json>", "Flap rate config as JSON object (Flap only)")
+    // FourMeme specific
+    .option("--fourmeme-rate-conf <json>", "FourMeme rate config as JSON object (FourMeme only)")
+    // BAGS specific
+    .option("--bags-fee-share-list <json>", "BAGS fee share list as JSON array (BAGS only)")
+    // Bonk specific
+    .option("--bonk-model <model>", "Bonk model identifier (bonk DEX only)")
+    // Multi-wallet buy
+    .option("--buy-wallets <json>", "Multi-wallet buy config as JSON array [{from_address, buy_amt}]")
+    .option("--snip-buy-wallets <json>", "Snipe-buy wallet config as JSON array [{from_address, buy_amt}]")
+    .option("--interval-seconds <n>", "Interval between multi-wallet buys in seconds", parseInt)
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (!opts.image && !opts.imageUrl) {
@@ -67,6 +97,29 @@ export function registerCookingCommands(program: Command): void {
       if (opts.tipFee) params.tip_fee = opts.tipFee;
       if (opts.gasPrice) params.gas_price = opts.gasPrice;
       if (opts.antiMev) params.is_anti_mev = true;
+      if (opts.antiMevMode) params.anti_mev_mode = opts.antiMevMode;
+      if (opts.raisedToken != null) params.raised_token = opts.raisedToken;
+      if (opts.devWalletBps != null) params.dev_wallet_bps = opts.devWalletBps;
+      if (opts.maxFeePerGas) params.max_fee_per_gas = opts.maxFeePerGas;
+      if (opts.maxPriorityFeePerGas) params.max_priority_fee_per_gas = opts.maxPriorityFeePerGas;
+      if (opts.devGas) params.dev_gas = opts.devGas;
+      if (opts.devPriority) params.dev_priority = opts.devPriority;
+      if (opts.devTip) params.dev_tip = opts.devTip;
+      if (opts.approveVision) params.approve_vision = opts.approveVision;
+      if (opts.source) params.source = opts.source;
+      if (opts.isMayhem) params.is_mayhem = true;
+      if (opts.isCashback) params.is_cashback = true;
+      if (opts.isRevokeFeeAuth) params.is_revoke_fee_auth = true;
+      if (opts.isAgent) params.is_agent = true;
+      if (opts.agentBps != null) params.agent_bps = opts.agentBps;
+      if (opts.pumpFeeShareList) params.pump_fee_share_list = JSON.parse(opts.pumpFeeShareList);
+      if (opts.flapRateConf) params.flap_rate_conf = JSON.parse(opts.flapRateConf);
+      if (opts.fourmemeRateConf) params.fourmeme_rate_conf = JSON.parse(opts.fourmemeRateConf);
+      if (opts.bagsFeeShareList) params.bags_fee_share_list = JSON.parse(opts.bagsFeeShareList);
+      if (opts.bonkModel) params.bonk_model = opts.bonkModel;
+      if (opts.buyWallets) params.buy_wallets = JSON.parse(opts.buyWallets);
+      if (opts.snipBuyWallets) params.snip_buy_wallets = JSON.parse(opts.snipBuyWallets);
+      if (opts.intervalSeconds != null) params.interval_seconds = opts.intervalSeconds;
       const client = new OpenApiClient(getConfig(true));
       const data = await client.createToken(params).catch(exitOnError);
       printResult(data, opts.raw);


### PR DESCRIPTION
- Correct supported launchpad table: sol(pump/bonk/bags), bsc(fourmeme/flap), base(klik/clanker)
- Document raised_token per DEX: pump→USDC, bonk→USD1, bags/base→empty, flap→BNB only
- Mark --anti-mev and --anti-mev-mode as SOL-only
- Fix anti_mev_mode values: normal/secure (was flashbots/bloxroute)
- Update cli-usage.md cooking create section with per-chain DEX and raise token table