### PR TITLE
fix(signer): URL-encode query values in buildMessage to match URLSearchParams

### DIFF
--- a/src/client/signer.ts
+++ b/src/client/signer.ts
@@ -32,8 +32,10 @@ export function buildAuthQuery(): { timestamp: number; client_id: string } {
 /**
  * Build the signature message (signed auth)
  * Format: {sub_path}:{sorted_query_string}:{request_body}:{timestamp}
- * sorted_query_string: all query params (including timestamp, client_id) sorted alphabetically by key.
- * Array values are serialized as repeated k=v pairs (same as buildUrl / URLSearchParams), sorted by value.
+ * sorted_query_string: all query params (including timestamp, client_id) sorted alphabetically by key,
+ *   URL-encoded via application/x-www-form-urlencoded (same as buildUrl / URLSearchParams) so the
+ *   signature matches the literal query string the server receives.
+ *   Array values are serialized as repeated k=v pairs, sorted by value.
  */
 export function buildMessage(
   subPath: string,
@@ -46,12 +48,18 @@ export function buildMessage(
     .flatMap((k) => {
       const v = queryParams[k];
       if (Array.isArray(v)) {
-        return [...v].sort().map((item) => `${k}=${item}`);
+        return [...v].sort().map((item) => encodeQueryPair(k, item));
       }
-      return [`${k}=${v}`];
+      return [encodeQueryPair(k, String(v))];
     })
     .join("&");
   return `${subPath}:${sortedQs}:${body}:${timestamp}`;
+}
+
+function encodeQueryPair(k: string, v: string): string {
+  const p = new URLSearchParams();
+  p.set(k, v);
+  return p.toString();
 }
 
 /**


### PR DESCRIPTION
## Summary

- `buildMessage` was using raw string interpolation (`${k}=${v}`) without URL-encoding, while `buildUrl` uses `URLSearchParams` (which does encode).
- Cursor values from paginated endpoints (e.g. `portfolio holdings --hide-closed false`) can contain base64 characters (`+`, `/`, `=`). `URLSearchParams` encodes these as `%2B`, `%2F`, `%3D` in the URL, but the signature was computed over the raw form — mismatch → 401 on page 2+.
- Simple parameter values (`true`, `false`, wallet addresses, chain names) are all URL-safe and encode to themselves, so existing signed requests are unaffected.

## Root cause

```
Signature message:  cursor=abc/def=          ← raw, no encoding
URL sent to server: cursor=abc%2Fdef%3D      ← URLSearchParams encoded
Server verifies against URL form → mismatch → 401
```

**Why `--hide-closed true` appeared to work**: wallets with fewer than 50 open positions return no `next` cursor on page 1. The `$()` extraction produces empty string, `--cursor ""` is falsy and silently ignored — the outer command just re-fetches page 1. No cursor was actually being signed.

## Fix

Changed `buildMessage` to use `URLSearchParams` for each key-value pair, matching `buildUrl`'s encoding exactly.

## Test plan

- [ ] `portfolio holdings --hide-closed false --limit 50 --cursor <cursor_with_special_chars>` should return page 2 without 401
- [ ] `portfolio holdings --hide-closed true` (no cursor) still works
- [ ] swap / follow-wallet signed requests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)