### PR TITLE
fix(signer): percent-encode query params in buildMessage to match server

### DIFF
--- a/src/client/signer.ts
+++ b/src/client/signer.ts
@@ -44,11 +44,12 @@ export function buildMessage(
   const sortedQs = Object.keys(queryParams)
     .sort()
     .flatMap((k) => {
+      const ek = encodeURIComponent(k);
       const v = queryParams[k];
       if (Array.isArray(v)) {
-        return [...v].sort().map((item) => `${k}=${item}`);
+        return [...v].sort().map((item) => `${ek}=${encodeURIComponent(item)}`);
       }
-      return [`${k}=${v}`];
+      return [`${ek}=${encodeURIComponent(String(v))}`];
     })
     .join("&");
   return `${subPath}:${sortedQs}:${body}:${timestamp}`;


### PR DESCRIPTION
Server's CanonicalQueryString uses url.QueryEscape on all keys and values, but buildMessage was using raw string interpolation. Cursor values (base64) contain +, =, / which diverge under encoding — causing 401 on all paginated signed requests (e.g. portfolio holdings page 2+).