### PR TITLE
feat(cooking): complete create_token params, auto-sell, and fixes

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -730,31 +730,71 @@ gmgn-cli cooking create \
   --buy-amt <amount> \
   [--image <base64> | --image-url <url>] \
   [--slippage <n> | --auto-slippage] \
+  [--description <text>] \
   [--website <url>] [--twitter <url>] [--telegram <url>] \
-  [--priority-fee <sol>] [--tip-fee <amount>] [--gas-price <amount>] \
-  [--anti-mev] \
+  [--fee <amount>] [--priority-fee <sol>] [--tip-fee <amount>] [--gas-price <amount>] \
+  [--max-fee-per-gas <amount>] [--max-priority-fee-per-gas <amount>] \
+  [--anti-mev] [--anti-mev-mode <normal|secure>] \
+  [--raised-token <symbol>] \
+  [--dev-wallet-bps <n>] [--dev-gas <amount>] [--dev-priority <amount>] [--dev-tip <amount>] [--dev-max-fee-per-gas <amount>] \
+  [--approve-vision <v1|v2>] [--source <source>] \
+  [--is-mayhem] [--is-cashback] [--is-buy-back] \
+  [--pump-fee-share-list <json>] \
+  [--flap-rate-conf <json>] \
+  [--fourmeme-rate-conf <json>] \
+  [--bags-fee-share-list <json>] \
+  [--bonk-model <model>] \
+  [--buy-wallets <json>] [--snip-buy-wallets <json>] [--interval-seconds <n>] \
+  [--buy-trade-config <json>] [--sell-trade-config <json>] [--sell-configs <json>] \
   [--raw]
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `ton` |
-| `--dex` | Yes | Launchpad: `pump` / `raydium` / `pancakeswap` / `flap` / `fourmeme` / `bonk` / `bags` / ... |
+| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--dex` | Yes | Launchpad per chain: `pump` / `bonk` / `bags` (sol), `fourmeme` / `flap` (bsc), `klik` / `clanker` (base) |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--name` | Yes | Token name |
 | `--symbol` | Yes | Token symbol |
 | `--buy-amt` | Yes | Initial buy amount in native token (e.g. `0.01` SOL) |
 | `--image` | No* | Token logo as base64-encoded data (max 2MB decoded); required unless `--image-url` is used |
 | `--image-url` | No* | Token logo URL; required unless `--image` is used |
+| `--slippage` | No* | Slippage tolerance, e.g. `0.01` = 1%; required unless `--auto-slippage` is used |
+| `--auto-slippage` | No* | Enable automatic slippage; required unless `--slippage` is used |
+| `--description` | No | Token description / project pitch |
 | `--website` | No | Website URL |
 | `--twitter` | No | Twitter link |
 | `--telegram` | No | Telegram link |
-| `--slippage` | No | Slippage tolerance, e.g. `0.01` = 1% |
-| `--auto-slippage` | No | Enable automatic slippage |
-| `--priority-fee` | No | Priority fee in SOL (SOL only) |
-| `--tip-fee` | No | Tip fee |
-| `--gas-price` | No | Gas price in wei (EVM chains) |
-| `--anti-mev` | No | Enable anti-MEV protection |
+| `--fee` | No | Base gas / fee |
+| `--priority-fee` | No | Priority fee in SOL (**SOL only**, ≥ 0.0001 SOL) |
+| `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on BASE) |
+| `--gas-price` | No | Gas price in wei (**EVM only**) |
+| `--max-fee-per-gas` | No | Max fee per gas in wei (**EVM only**) |
+| `--max-priority-fee-per-gas` | No | Max priority fee per gas in wei (**EVM only**) |
+| `--anti-mev` | No | Enable anti-MEV protection (**SOL only**) |
+| `--anti-mev-mode` | No | Anti-MEV mode: `normal` / `secure` (**SOL only**) |
+| `--raised-token` | No | Raise token symbol: `pump`→`USDC`; `bonk`→`USD1`; `fourmeme`→`USDT`/`USD1`; omit for native |
+| `--dev-wallet-bps` | No | Dev wallet fee share in basis points (100 = 1%) |
+| `--dev-gas` | No | Dev gas amount |
+| `--dev-priority` | No | Dev priority fee |
+| `--dev-tip` | No | Dev tip fee |
+| `--dev-max-fee-per-gas` | No | Dev tx feeCap in wei (**EVM EIP-1559**) |
+| `--approve-vision` | No | Approve vision version: `v1` / `v2` (default: `v2`) |
+| `--source` | No | Traffic source identifier |
+| `--is-mayhem` | No | Enable Mayhem mode (**Pump.fun only**) |
+| `--is-cashback` | No | Enable Cashback (**Pump.fun only**) |
+| `--is-buy-back` | No | Enable Agent Auto Buyback (**Pump.fun only**) |
+| `--pump-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"github","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
+| `--flap-rate-conf` | No | Rate config as JSON object (**Flap only**) |
+| `--fourmeme-rate-conf` | No | Rate config as JSON object (**FourMeme only**) |
+| `--bags-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**BAGS only**) |
+| `--bonk-model` | No | Bonk model identifier (**bonk DEX only**) |
+| `--buy-wallets` | No | Multi-wallet buy config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--snip-buy-wallets` | No | Snipe-buy wallet config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--interval-seconds` | No | Interval between multi-wallet buys in seconds |
+| `--buy-trade-config` | No | Buy-side trade config for CondMarket orders as JSON (TradeParam) |
+| `--sell-trade-config` | No | Sell-side trade config for auto-sell / pending_sell as JSON (TradeParam) |
+| `--sell-configs` | No | Auto-sell strategy list as JSON array (CookingSellConfig[]): `[{"sell_type":"delay_sell","delay_sec":<n>,"sell_ratio":"0.5","wallet_addresses":["<addr>"]}]` |
 
 **Response fields (data):**
 

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -26,7 +26,7 @@ Use the `gmgn-cli` tool to create a token on a launchpad platform or query token
 
 - **Status polling via `order get`** — `cooking create` is asynchronous. The immediate response may show `pending`. Poll with `gmgn-cli order get --chain <chain> --order-id <order_id>` until `confirmed`. The new token's contract address is in the `report.output_token` field of the `order get` response, not in the initial create response.
 
-- **Signed auth** — `cooking create` requires both `GMGN_API_KEY` and `GMGN_PRIVATE_KEY`. The private key never leaves the machine — the CLI uses it only for local signing. `cooking stats` uses normal auth (API Key only).
+- **Signed auth** — `cooking create` requires both `GMGN_API_KEY` and `GMGN_PRIVATE_KEY`. The private key never leaves the machine — the CLI uses it only for local signing. `cooking stats` uses exist auth (API Key only).
 
 - **Slippage** — The initial buy is executed as part of the same transaction as token creation. Slippage applies to that buy. Use `--slippage` (decimal, e.g. `0.01` = 1%) or `--auto-slippage`. One of the two is required when `--buy-amt` is set.
 
@@ -43,7 +43,7 @@ Use the `gmgn-cli` tool to create a token on a launchpad platform or query token
 
 | Sub-command | Description |
 |-------------|-------------|
-| `cooking stats` | Get token creation count statistics grouped by launchpad platform (normal auth) |
+| `cooking stats` | Get token creation count statistics grouped by launchpad platform (exist auth) |
 | `cooking create` | Deploy a new token on a launchpad platform (signed auth) |
 
 ## Supported Chains
@@ -536,7 +536,7 @@ Once all information is collected, present the pre-create confirmation summary (
 ## Notes
 
 - `cooking create` uses **signed auth** (API Key + signature) — CLI handles signing automatically.
-- `cooking stats` uses normal auth (API Key only — no private key needed).
+- `cooking stats` uses exist auth (API Key only — no private key needed).
 - The new token's mint address is in `report.output_token` from `gmgn-cli order get`, not in the initial `cooking create` response.
 - Use `--raw` on any command to get single-line JSON for further processing.
 

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gmgn-cooking
-description: "[FINANCIAL EXECUTION] Create and launch meme coins and crypto tokens on launchpads (Pump.fun, PancakeSwap, FourMeme, Bonk, BAGS, Flap, Raydium, etc.) via bonding curve fair launch, or query token creation stats by launchpad via GMGN API. Requires explicit user confirmation. Use when user asks to create a token, launch a meme coin, cook a coin, deploy on a launchpad, or check launchpad creation stats on Solana, BSC, Base, ETH, or TON."
+description: "[FINANCIAL EXECUTION] Create and launch meme coins and crypto tokens on launchpads (Pump.fun, FourMeme, Bonk, BAGS, Flap, Klik, Clanker, etc.) via bonding curve fair launch, or query token creation stats by launchpad via GMGN API. Requires explicit user confirmation. Use when user asks to create a token, launch a meme coin, cook a coin, deploy on a launchpad, or check launchpad creation stats on Solana, BSC, or Base."
 argument-hint: "stats | [create --chain <chain> --dex <dex> --from <addr> --name <name> --symbol <sym> --buy-amt <n> (--image <base64> | --image-url <url>)]"
 metadata:
   cliHelp: "gmgn-cli cooking --help"
@@ -24,9 +24,9 @@ Use the `gmgn-cli` tool to create a token on a launchpad platform or query token
 
 - **Image input** — Token logo can be provided as base64-encoded data (`--image`, max 2MB decoded) or a publicly accessible URL (`--image-url`). Provide one or the other — not both. If the user gives a file path, read and base64-encode it before passing to `--image`. If they give a URL, use `--image-url` directly.
 
-- **Status polling via `order get`** — `cooking create` is asynchronous. The immediate response may show `pending`. Poll with `gmgn-cli order get --chain <chain> --order-id <order_id>` until `confirmed`. The new token's contract address is in the `output_token` field of the `order get` response, not in the initial create response.
+- **Status polling via `order get`** — `cooking create` is asynchronous. The immediate response may show `pending`. Poll with `gmgn-cli order get --chain <chain> --order-id <order_id>` until `confirmed`. The new token's contract address is in the `report.output_token` field of the `order get` response, not in the initial create response.
 
-- **Signed auth** — `cooking create` requires both `GMGN_API_KEY` and `GMGN_PRIVATE_KEY`. The private key never leaves the machine — the CLI uses it only for local signing. `cooking stats` uses exist auth (API Key only).
+- **Signed auth** — `cooking create` requires both `GMGN_API_KEY` and `GMGN_PRIVATE_KEY`. The private key never leaves the machine — the CLI uses it only for local signing. `cooking stats` uses normal auth (API Key only).
 
 - **Slippage** — The initial buy is executed as part of the same transaction as token creation. Slippage applies to that buy. Use `--slippage` (decimal, e.g. `0.01` = 1%) or `--auto-slippage`. One of the two is required when `--buy-amt` is set.
 
@@ -43,22 +43,24 @@ Use the `gmgn-cli` tool to create a token on a launchpad platform or query token
 
 | Sub-command | Description |
 |-------------|-------------|
-| `cooking stats` | Get token creation count statistics grouped by launchpad platform (exist auth) |
+| `cooking stats` | Get token creation count statistics grouped by launchpad platform (normal auth) |
 | `cooking create` | Deploy a new token on a launchpad platform (signed auth) |
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `ton`
+`sol` / `bsc` / `base`
 
 ## Supported Launchpads by Chain
 
-| Chain | `--dex` values |
-|-------|----------------|
-| `sol` | `pump` / `raydium` / `bonk` / `bags` / `memoo` / `letsbonk` / `bonkers` |
-| `bsc` | `pancakeswap` / `flap` / `fourmeme` |
-| `base` | `clanker` / `flaunch` / `baseapp` / `basememe` / `zora` / `virtuals_v2` |
+| Chain  | `--dex` values         | Raise token (`--raised-token`) |
+| ------ | ---------------------- | ------------------------------ |
+| `sol`  | `pump`, `bonk`, `bags` | `pump`: `""` (SOL) or `USDC`; `bonk`: `""` (SOL) or `USD1`; `bags`: `""` (SOL only) |
+| `bsc`  | `fourmeme`, `flap`     | `fourmeme`: `""` (BNB), `USD1`, `USDT`; `flap`: `""` (BNB only) |
+| `base` | `klik`, `clanker`      | `""` only (quote token fixed to WETH) |
 
-When the user names a platform colloquially (e.g. "pump.fun", "four.meme", "PancakeSwap"), map it to the correct `--dex` identifier from this table before running the command.
+When the user names a platform colloquially (e.g. "pump.fun", "four.meme"), map it to the correct `--dex` identifier from this table before running the command.
+
+**Anti-MEV** (`--anti-mev`) is only supported on `sol`. Passing it on `bsc` or `base` will return a 400 error.
 
 ## Prerequisites
 
@@ -121,33 +123,180 @@ gmgn-cli cooking stats [--raw]
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `launchpad` | string | Launchpad identifier (e.g. `pump`, `raydium`, `pancakeswap`) |
+| `launchpad` | string | Launchpad identifier (e.g. `pump`, `bonk`, `fourmeme`) |
 | `token_count` | int | Number of tokens created via GMGN on that launchpad |
 
 ## `cooking create` Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | Chain: `sol` / `bsc` / `base` / `eth` / `ton` |
+| `--chain` | Yes | Chain: `sol` / `bsc` / `base` |
 | `--dex` | Yes | Launchpad platform identifier — see Supported Launchpads table. Never guess this value. |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--name` | Yes | Token full name (e.g. `Doge Killer`) |
 | `--symbol` | Yes | Token ticker symbol (e.g. `DOGEK`) |
-| `--description` | No | Token description / project pitch |
 | `--buy-amt` | Yes | Initial buy amount in **human-readable native token units** (e.g. `0.01` = 0.01 SOL). This is NOT in smallest unit. |
 | `--image` | No* | Token logo as **base64-encoded** data (max 2MB decoded). Mutually exclusive with `--image-url`. One of the two is required. |
 | `--image-url` | No* | Token logo as a publicly accessible URL. Mutually exclusive with `--image`. One of the two is required. |
 | `--slippage` | No* | Slippage tolerance, e.g. `0.01` = 1%. **Mutually exclusive with `--auto-slippage`** — provide one or the other. |
 | `--auto-slippage` | No* | Enable automatic slippage. **Mutually exclusive with `--slippage`.** |
+| `--description` | No | Token description / project pitch |
 | `--website` | No | Project website URL |
 | `--twitter` | No | Twitter / X URL |
 | `--telegram` | No | Telegram group URL |
-| `--priority-fee` | No | Priority fee in SOL (SOL only, ≥ 0.0001 SOL) |
-| `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on ETH/BASE) |
-| `--gas-price` | No | Gas price in wei (EVM chains) |
-| `--anti-mev` | No | Enable anti-MEV protection |
+| `--fee` | No | Base gas / fee |
+| `--priority-fee` | No | Priority fee in SOL (**SOL only**, ≥ 0.0001 SOL) |
+| `--tip-fee` | No | Tip fee (SOL ≥ 0.00001 / BSC ≥ 0.000001 BNB; ignored on BASE) |
+| `--gas-price` | No | Gas price in wei (EVM chains: BSC / BASE) |
+| `--max-fee-per-gas` | No | Max fee per gas in wei (**EVM only**) |
+| `--max-priority-fee-per-gas` | No | Max priority fee per gas in wei (**EVM only**) |
+| `--anti-mev` | No | Enable anti-MEV protection (**SOL only**; rejected on BSC / BASE) |
+| `--anti-mev-mode` | No | Anti-MEV mode: `normal` / `secure` (**SOL only**) |
+| `--raised-token` | No | Raise token symbol. `pump`: `USDC`; `bonk`: `USD1`; `fourmeme`: `USDT` / `USD1`; omit or `""` for native |
+| `--dev-wallet-bps` | No | Dev wallet fee share in basis points (100 = 1%) |
+| `--dev-gas` | No | Dev gas amount |
+| `--dev-priority` | No | Dev priority fee |
+| `--dev-tip` | No | Dev tip fee |
+| `--dev-max-fee-per-gas` | No | Dev tx feeCap in wei (**EVM EIP-1559**) |
+| `--approve-vision` | No | Approve vision version: `v1` / `v2` (default: `v2`) |
+| `--source` | No | Traffic source identifier |
+| `--is-mayhem` | No | Enable Mayhem mode (**Pump.fun only**) |
+| `--is-cashback` | No | Enable Cashback (**Pump.fun only**) |
+| `--is-buy-back` | No | Enable Agent Auto Buyback (**Pump.fun only**) |
+| `--pump-fee-share-list` | No | Pump.fun fee share list as JSON array: `[{"provider":"github","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
+| `--flap-rate-conf` | No | Flap rate config as JSON object (**Flap only**) |
+| `--fourmeme-rate-conf` | No | FourMeme rate config as JSON object (**FourMeme only**) |
+| `--bags-fee-share-list` | No | BAGS fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**BAGS only**) |
+| `--bonk-model` | No | Bonk model identifier (**bonk DEX only**) |
+| `--buy-wallets` | No | Multi-wallet buy config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--snip-buy-wallets` | No | Snipe-buy wallet config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
+| `--interval-seconds` | No | Interval between multi-wallet buys in seconds |
+| `--buy-trade-config` | No | Buy-side trade config for CondMarket orders as JSON (TradeParam) — see Advanced API Fields |
+| `--sell-trade-config` | No | Sell-side trade config for auto-sell / pending_sell as JSON (TradeParam) — see Advanced API Fields |
+| `--sell-configs` | No | Auto-sell strategy list as JSON array (CookingSellConfig[]) — see Auto-Sell Configuration |
 
 \* `--image` or `--image-url`: provide exactly one. `--slippage` or `--auto-slippage`: provide exactly one.
+
+## Advanced API Fields
+
+The structured flags (`--pump-fee-share-list`, `--bags-fee-share-list`, `--flap-rate-conf`, `--fourmeme-rate-conf`, `--buy-wallets`, `--snip-buy-wallets`, `--buy-trade-config`, `--sell-trade-config`, `--sell-configs`) each accept a **JSON string**. This section documents the exact JSON schema for each.
+
+**Basis-points rule:** any field named `*_bps` / `basic_points` is in basis points (`100` = 1%). Where a section says the shares must sum, all entries must add up to exactly **10000** (FourMeme uses whole percents summing to **100** instead — see below).
+
+**Always talk to the user in percentages, never basis points.** When asking for or confirming any share, fee, or split, phrase it as a percentage (e.g. *"What % goes to this wallet?"* → user says `"50%"`). Convert to the field's unit yourself when building the JSON — never ask the user for a raw bps number:
+
+| User says | `*_bps` field (×100) | FourMeme `*_rate` field (×1) |
+|---|---|---|
+| `5%` | `500` | `5` |
+| `50%` | `5000` | `50` |
+| `100%` | `10000` | `100` |
+
+Never set a fee-share split without the user's explicit instruction — it permanently routes token revenue to the listed accounts.
+
+### Pump.fun (`--dex pump`)
+
+> `is_mayhem`, `is_cashback`, `is_buy_back` use their matching CLI flags (`--is-mayhem`, `--is-cashback`, `--is-buy-back`). `pump_fee_share_list` is passed via `--pump-fee-share-list`.
+
+| Field | CLI flag | Description |
+|---|---|---|
+| `pump_fee_share_list` | `--pump-fee-share-list <json>` | Fee-share list — see JSON schema below |
+| `is_buy_back` | `--is-buy-back` | Enable Agent Auto Buyback |
+
+**JSON schema for `--pump-fee-share-list`** — array of objects:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `provider` | string | Yes | `github` / `wallet` |
+| `username` | string | Yes | Username for `github`; a SOL address when `wallet` |
+| `basic_points` | int | Yes | Share in bps — all entries must sum to **10000** |
+
+Example: `--pump-fee-share-list '[{"provider":"github","username":"handle","basic_points":10000}]'`
+
+### Bonk (`--dex bonk`)
+
+`dev_wallet_bps` → `--dev-wallet-bps`, `bonk_model` → `--bonk-model`. No additional structured fields.
+
+### BAGS (`--dex bags`)
+
+`dev_wallet_bps` → `--dev-wallet-bps`. `bags_fee_share_list` is passed via `--bags-fee-share-list`.
+
+**JSON schema for `--bags-fee-share-list`** — array of objects:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `provider` | string | Yes | `twitter` / `solana` / `kick` / `github` |
+| `username` | string | Yes | Platform username |
+| `basic_points` | int | Yes | Share in bps — combined with `dev_wallet_bps`, all must sum to **10000** |
+
+### Flap (`--dex flap`)
+
+`flap_rate_conf` is passed via `--flap-rate-conf`.
+
+**JSON schema for `--flap-rate-conf`** — single object:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `beneficiary` | string | Yes | Fee recipient address |
+| `tax_rate` | int | Conditional | V5 unified tax rate in bps, e.g. 5% → `500` |
+| `buy_tax_rate` | int | Conditional | V6 separate buy tax rate in bps |
+| `sell_tax_rate` | int | Conditional | V6 separate sell tax rate in bps |
+| `mkt_bps` | int | Yes | Marketing / donation fund share |
+| `deflation_bps` | int | Yes | Burn (supply-reduction) share |
+| `dividend_bps` | int | Yes | Dividend (holder-reward) share |
+| `lp_bps` | int | Yes | Liquidity share |
+| `minimum_share_balance` | int | Yes | Min holding to qualify for dividends — minimum **10000** tokens |
+| `recipient_type` | string | Yes | `split` (proportional) / `gift` |
+| `twitter_account` | string | Yes | Twitter username |
+| `split_conf` | array | Yes | Split list — see below |
+
+`split_conf` entries: `{ "recipient": "<address>", "bps": <n> }` — all `bps` must sum to **10000**.
+
+> - Use `tax_rate` for V5 (unified rate); use `buy_tax_rate` + `sell_tax_rate` for V6 (separate rates).
+> - When the tax rate > 0: `mkt_bps + deflation_bps + dividend_bps + lp_bps` must sum to **10000**. When `lp_bps > 0`: `minimum_share_balance` must be > 0.
+
+### FourMeme (`--dex fourmeme`)
+
+`fourmeme_rate_conf` is passed via `--fourmeme-rate-conf`.
+
+> `fourmeme_user_login_sign`, `is_approve_allowance`, `is_raised_swap` are broker/jobs **internal** fields — the public API does not accept them, so there is no flag. The multi-quote raise-token retry is handled server-side automatically (poll `order get`); the caller never sets these.
+
+**JSON schema for `--fourmeme-rate-conf`** — single object:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fee_plan` | bool | No | Enable the fee plan |
+| `recipient_address` | string | Yes | Fee recipient address |
+| `fee_rate` | int | Yes | Fee rate, e.g. 5% → `5` (whole percent, not bps) |
+| `burn_rate` | int | Yes | Burn share |
+| `divide_rate` | int | Yes | Dividend share |
+| `liquidity_rate` | int | Yes | Liquidity share |
+| `recipient_rate` | int | Yes | Recipient share |
+| `min_sharing` | int | Yes | Minimum sharing threshold |
+
+> When `fee_rate > 0`: `burn_rate + divide_rate + liquidity_rate + recipient_rate` must sum to **100**. When `recipient_rate > 0`: `min_sharing` must be > 0.
+
+## Auto-Sell Configuration
+
+`sell_configs` is passed via `--sell-configs` as a JSON array. It schedules conditional sell orders to execute automatically once the token launch succeeds. Omit entirely for a standard launch with no auto-sell.
+
+`--sell-configs` is a JSON array of `CookingSellConfig` objects:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `sell_type` | string | Yes | `delay_sell` / `limit_order` |
+| `delay_sec` | int64 | Conditional | Seconds after buy to trigger; required when `sell_type = delay_sell` |
+| `delay_mili_sec` | int64 | No | Milliseconds after buy to trigger; takes precedence over `delay_sec` |
+| `sell_ratio` | string | Yes | Fraction to sell — `"1"` = 100%, `"0.5"` = 50% |
+| `check_price` | string | Conditional | Market cap in USD to trigger sell; required when `sell_type = limit_order` |
+| `wallet_addresses` | []string | Yes | Wallets this strategy applies to (empty array = inert) |
+
+Example: `--sell-configs '[{"sell_type":"delay_sell","delay_sec":60,"sell_ratio":"0.5","wallet_addresses":["<addr>"]}]'`
+
+The buy/sell execution params for these CondMarket orders (slippage, fees, anti-MEV) can be tuned separately via `--buy-trade-config` / `--sell-trade-config` (TradeParam JSON). They do **not** affect the main creation tx, and fall back to the outer-level transaction flags when omitted.
+
+> - **`check_price` is total market cap in USD** — e.g. `"50000"` triggers at a $50,000 market cap.
+> - `wallet_addresses` may mix `from_address` and `buy_wallets` entries. The server creates `signal_cooking` for snipe wallets and `pending_sell` for main/bundle wallets automatically.
+> - A wallet can carry multiple strategies (e.g. delay-sell 50%, then limit-sell the rest); each applies independently.
 
 ## `cooking create` Response Fields
 
@@ -190,21 +339,7 @@ gmgn-cli cooking create \
   --slippage 0.01 \
   --priority-fee 0.001
 
-# Create a token on PancakeSwap (BSC) — with URL image and social links
-gmgn-cli cooking create \
-  --chain bsc \
-  --dex pancakeswap \
-  --from <wallet_address> \
-  --name "BSC Token" \
-  --symbol BSCT \
-  --buy-amt 0.05 \
-  --image-url https://example.com/logo.png \
-  --slippage 0.02 \
-  --gas-price 5000000000 \
-  --website https://mytoken.io \
-  --twitter https://twitter.com/mytoken
-
-# Create a token on FourMeme (BSC) — using base64 image from local file
+# Create a token on FourMeme (BSC) — base64 image + USD1 raise token
 gmgn-cli cooking create \
   --chain bsc \
   --dex fourmeme \
@@ -213,12 +348,13 @@ gmgn-cli cooking create \
   --symbol FOUR \
   --buy-amt 0.05 \
   --image "$(base64 -i /path/to/logo.png)" \
-  --auto-slippage
+  --auto-slippage \
+  --raised-token USD1
 
-# Create a token on letsbonk (SOL)
+# Create a token on Bonk (SOL) with anti-MEV
 gmgn-cli cooking create \
   --chain sol \
-  --dex letsbonk \
+  --dex bonk \
   --from <wallet_address> \
   --name "Bonk Token" \
   --symbol BNKT \
@@ -227,6 +363,17 @@ gmgn-cli cooking create \
   --auto-slippage \
   --anti-mev
 
+# Create on Pump.fun with auto-sell: sell 50% 60s after buy
+gmgn-cli cooking create \
+  --chain sol \
+  --dex pump \
+  --from <wallet_address> \
+  --name "My Token" \
+  --symbol MAT \
+  --buy-amt 0.01 \
+  --image-url https://example.com/logo.png \
+  --auto-slippage \
+  --sell-configs '[{"sell_type":"delay_sell","delay_sec":60,"sell_ratio":"0.5","wallet_addresses":["<wallet_address>"]}]'
 ```
 
 ## Output Format
@@ -247,9 +394,14 @@ Initial Buy:  {--buy-amt} {native currency} (e.g. 0.01 SOL)
 Slippage:     {--slippage}% (or "auto")
 Image:        {--image-url or "base64 provided"}
 Social:       {twitter / telegram / website if provided}
+Modes:        {Mayhem / Cashback / Agent Auto Buyback if set, else "none"}
+Fee Share:    {recipient → % list if set, else "none"}
+Auto-Sell:    {sell_configs summary if set, else "none"}
 
 Reply "confirm" to deploy this token. This action is IRREVERSIBLE.
 ```
+
+Omit the Modes / Fee Share / Auto-Sell lines if none were configured — or show them as `none` — but if any **are** set, they MUST appear here so the user re-confirms them explicitly.
 
 ### Post-create Receipt
 
@@ -259,7 +411,7 @@ After polling confirms a successful deployment:
 ✅ Token Created
 
 Token:    {--name} ({--symbol})
-Address:  {output_token from order get}
+Address:  {report.output_token from order get}
 Chain:    {chain}
 Platform: {--dex}
 Tx:       {explorer link for hash}
@@ -273,7 +425,6 @@ Block explorer links:
 | sol   | `https://solscan.io/tx/<hash>` |
 | bsc   | `https://bscscan.com/tx/<hash>` |
 | base  | `https://basescan.org/tx/<hash>` |
-| eth   | `https://etherscan.io/tx/<hash>` |
 
 ## Guided Launch Flow
 
@@ -287,23 +438,19 @@ Ask: *"Which chain and platform?"*
 
 Show the options concisely:
 
-| Chain | Platform | `--dex` |
-|-------|----------|---------|
-| Solana | Pump.fun | `pump` |
-| Solana | letsbonk | `letsbonk` |
-| Solana | Raydium | `raydium` |
-| Solana | BAGS | `bags` |
-| Solana | Memoo | `memoo` |
-| Solana | Bonkers | `bonkers` |
-| BSC | FourMeme | `fourmeme` |
-| BSC | PancakeSwap | `pancakeswap` |
-| BSC | Flap | `flap` |
-| Base | Clanker | `clanker` |
-| Base | Zora | `zora` |
-| Base | Flaunch | `flaunch` |
-| Base | Virtuals | `virtuals_v2` |
+| Chain  | Platform   | `--dex`    |
+| ------ | ---------- | ---------- |
+| Solana | Pump.fun   | `pump`     |
+| Solana | Bonk       | `bonk`     |
+| Solana | BAGS       | `bags`     |
+| BSC    | FourMeme   | `fourmeme` |
+| BSC    | Flap       | `flap`     |
+| Base   | Klik       | `klik`     |
+| Base   | Clanker    | `clanker`  |
 
 If the user is unsure, recommend: **Pump.fun (SOL)** or **FourMeme (BSC)**.
+
+The chosen platform determines which advanced options are available later in Step 7 (e.g. Mayhem/Cashback/Agent Auto Buyback on Pump.fun, fee-share splits on BAGS/Flap/FourMeme). Note the platform now; do not ask about advanced options yet.
 
 ### Step 2 — Token Name
 
@@ -343,9 +490,32 @@ Ask all optional fields together in one message:
 
 The user can reply with just the ones they have, or say "skip" / "none" to proceed.
 
-### Step 7 — Confirmation & Execute
+### Step 7 — Platform Modes, Fees & Auto-Sell (platform-dependent)
 
-Once all information is collected, present the pre-create confirmation summary (see Output Format section) and wait for the user to reply "confirm" before executing.
+After the basics are collected, ask **once** whether the user wants any advanced options for the platform they chose. Default everyone to a plain fair launch — only configure these when the user explicitly asks. Tailor the question to the selected platform; do not list options that don't apply to it.
+
+Ask: *"Want any advanced options, or launch with defaults? (reply 'defaults' to skip)"* — then offer the relevant subset.
+
+**Phrase the question around the platform the user picked — only ask about modes that exist on that platform.** For example, on **Pump.fun** ask specifically:
+- *"Enable Cashback mode?"* (`--is-cashback`)
+- *"Enable Agent Auto Buyback mode?"* (`--is-buy-back`)
+- *"Enable Mayhem mode?"* (`--is-mayhem`)
+- *"Set up a fee-share split?"* (`--pump-fee-share-list`)
+- *"Want me to remember these advanced settings for your next launch?"* — if yes, save them to memory so future launches can pre-fill the same choices.
+
+Bonk / BAGS / Flap / FourMeme have **no mode toggles** — for those, skip the mode questions and only ask about fee-share split and auto-sell.
+
+The relevant options per platform:
+
+- **Pump.fun modes** — Mayhem (`--is-mayhem`), Cashback (`--is-cashback`), Agent Auto Buyback (`--is-buy-back`).
+- **Fee-share split** — Pump.fun (`--pump-fee-share-list`), BAGS (`--dev-wallet-bps` + `--bags-fee-share-list`), Bonk (`--dev-wallet-bps`), Flap (`--flap-rate-conf`), FourMeme (`--fourmeme-rate-conf`). See [Advanced API Fields](#advanced-api-fields) for JSON schemas. **Warn the user this permanently routes token revenue to the listed accounts.** Always ask the user for shares as percentages — convert to bps yourself. Shares must add up to 100%.
+- **Auto-sell** — `--sell-configs` (JSON): delay-sell (sell a fraction N seconds after the buy) and/or limit-sell (sell once market cap hits a USD target). See [Auto-Sell Configuration](#auto-sell-configuration). Confirm the sell ratio and trigger before setting it.
+
+If the user says "defaults" / "skip" / "none", proceed with none of these set.
+
+### Step 8 — Confirmation & Execute
+
+Once all information is collected, present the pre-create confirmation summary (see Output Format section) and wait for the user to reply "confirm" before executing. If any advanced options from Step 7 were set, they MUST appear in the summary so the user re-confirms them explicitly.
 
 ---
 
@@ -355,18 +525,19 @@ Once all information is collected, present the pre-create confirmation summary (
 - **[REQUIRED] `--dex` validation** — Before running, look up the user's named platform in the Supported Launchpads table and resolve to the correct `--dex` identifier. Never guess or pass a freeform platform name. If the chain/platform combination is not in the table, tell the user it is unsupported.
 - **Slippage requirement** — Either `--slippage` or `--auto-slippage` must be provided. If the user did not specify, suggest `--auto-slippage` for volatile new tokens or ask for a preference.
 - **Image handling** — If the user provides a file path, run `base64 -i <path>` and pass the result to `--image`. If they provide a URL, use `--image-url`. If neither is provided, ask before building the confirmation — most platforms require a logo.
+- **Fee-share / bps inputs** — Always collect and confirm shares as percentages with the user; convert to basis points yourself (50% → `5000`). Never ask for a raw bps value.
 - **Address validation** — Validate `--from` wallet address format before submitting:
   - `sol`: base58, 32–44 characters
-  - `bsc` / `base` / `eth`: `0x` + 40 hex digits
+  - `bsc` / `base`: `0x` + 40 hex digits
 - **Chain-wallet compatibility** — SOL addresses are incompatible with EVM chains and vice versa. Warn the user and abort if the address format does not match the chain.
-- **Order polling** — After `cooking create`, if `status` is `pending`, poll `order get` every 2 seconds up to 30 seconds. The token address is in `output_token`. Do not report success until `status` is `confirmed`.
+- **Order polling** — After `cooking create`, if `status` is `pending`, poll `order get` every 2 seconds up to 30 seconds. The token address is in `report.output_token`. Do not report success until `status` is `confirmed`.
 - **Credential sensitivity** — `GMGN_API_KEY` and `GMGN_PRIVATE_KEY` can execute real transactions. Never log, display, or expose these values.
 
 ## Notes
 
 - `cooking create` uses **signed auth** (API Key + signature) — CLI handles signing automatically.
-- `cooking stats` uses exist auth (API Key only — no private key needed).
-- The new token's mint address is in `output_token` from `gmgn-cli order get`, not in the initial `cooking create` response.
+- `cooking stats` uses normal auth (API Key only — no private key needed).
+- The new token's mint address is in `report.output_token` from `gmgn-cli order get`, not in the initial `cooking create` response.
 - Use `--raw` on any command to get single-line JSON for further processing.
 
 ## References

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -170,27 +170,147 @@ export interface TokenSignalGroup {
   max_create_or_open_ts?: string;
 }
 
+export interface PumpFeeShareInfo {
+  provider: string;       // "github" | "wallet"
+  username: string;       // username for github; a SOL address when wallet
+  basic_points: number;
+}
+
+export interface BAGSFeeShareInfo {
+  provider: string;       // "twitter" | "solana" | "kick" | "github"
+  username: string;
+  basic_points: number;
+}
+
+export interface FlapRateConf {
+  tax_rate?: number;       // V5 unified tax rate, e.g. 5% -> 500
+  buy_tax_rate?: number;   // V6 separate buy tax rate
+  sell_tax_rate?: number;  // V6 separate sell tax rate
+  mkt_bps?: number;
+  deflation_bps?: number;
+  dividend_bps?: number;
+  lp_bps?: number;
+  minimum_share_balance?: number;
+  recipient_type?: string;
+  beneficiary?: string;
+  twitter_account?: string;
+  split_conf?: Array<{ recipient: string; bps: number }>;
+}
+
+export interface FourmemeRateConf {
+  fee_plan?: boolean;
+  fee_rate?: number;
+  burn_rate?: number;
+  divide_rate?: number;
+  liquidity_rate?: number;
+  recipient_rate?: number;
+  recipient_address?: string;
+  min_sharing?: number;
+}
+
+export interface BuyWalletInfo {
+  from_address: string;
+  buy_amt: string;
+}
+
+// Buy/sell execution config for CondMarket orders (snipe buy, auto-sell, pending_sell).
+// Does NOT affect the main creation tx. Falls back to outer-level fields when omitted.
+export interface TradeParam {
+  slippage?: number;
+  auto_slippage?: boolean;
+  fee?: string;
+  priority_fee?: string;
+  tip_fee?: string;
+  gas_price?: string;
+  max_priority_fee_per_gas?: string;
+  max_fee_per_gas?: string;
+  is_anti_mev?: boolean;   // backend currently forces true; passing has no effect
+  anti_mev_mode?: string;  // backend currently forces "secure"; passing has no effect
+}
+
+export interface CookingSellConfig {
+  sell_type: string;          // "delay_sell" | "limit_order"
+  delay_sec?: number;         // required when sell_type = "delay_sell"
+  delay_mili_sec?: number;    // optional; takes precedence over delay_sec
+  sell_ratio: string;         // "1" = 100%, "0.5" = 50%
+  check_price?: string;       // trigger market cap in USD; required when sell_type = "limit_order"
+  wallet_addresses: string[]; // empty array means the strategy is inert
+}
+
 export interface CreateTokenParams {
+  // Required
   chain: string;
   dex: string;
   from_address: string;
   name: string;
   symbol: string;
   buy_amt: string;
+
+  // Image (one required)
   image?: string;
   image_url?: string;
+
+  // Social
+  description?: string;
   website?: string;
   twitter?: string;
   telegram?: string;
+
+  // Transaction
   slippage?: number;
   auto_slippage?: boolean;
+
+  // Fees
+  fee?: string;
   priority_fee?: string;
   tip_fee?: string;
   gas_price?: string;
   max_priority_fee_per_gas?: string;
   max_fee_per_gas?: string;
+
+  // Anti-MEV (SOL only)
   is_anti_mev?: boolean;
   anti_mev_mode?: string;
+
+  // Advanced
+  raised_token?: string;
+  dev_gas?: string;
+  dev_priority?: string;
+  dev_tip?: string;
+  dev_max_fee_per_gas?: string;
+  approve_vision?: string;
+  source?: string;
+  dev_wallet_bps?: number;
+
+  // CondMarket buy/sell execution config (snipe / bundle / auto-sell)
+  buy_trade_config?: TradeParam;
+  sell_trade_config?: TradeParam;
+
+  // Auto-sell strategies created after a successful launch
+  sell_configs?: CookingSellConfig[];
+
+  // Pump.fun specific
+  is_mayhem?: boolean;
+  is_cashback?: boolean;
+  is_buy_back?: boolean;
+  pump_fee_share_list?: PumpFeeShareInfo[];
+
+  // Flap specific
+  flap_rate_conf?: FlapRateConf;
+
+  // FourMeme specific
+  fourmeme_rate_conf?: FourmemeRateConf;
+
+  // BAGS specific
+  bags_fee_share_list?: BAGSFeeShareInfo[];
+
+  // Bonk specific
+  bonk_model?: string;
+
+  // Multi-wallet buy
+  buy_wallets?: BuyWalletInfo[];
+  snip_buy_wallets?: BuyWalletInfo[];
+  interval_seconds?: number;
 }
 
 export class OpenApiClient {

--- a/src/commands/cooking.ts
+++ b/src/commands/cooking.ts
@@ -20,23 +20,57 @@ export function registerCookingCommands(program: Command): void {
   cooking
     .command("create")
     .description("Create a token on a launchpad platform (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / ton")
-    .requiredOption("--dex <dex>", "Launchpad: pump / raydium / pancakeswap / flap / fourmeme / bonk / bags / ...")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--dex <dex>", "Launchpad: pump / bonk / bags (sol) / fourmeme / flap (bsc) / klik / clanker (base)")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--name <name>", "Token name")
     .requiredOption("--symbol <symbol>", "Token symbol")
     .requiredOption("--buy-amt <amount>", "Initial buy amount in native token (e.g. 0.01 SOL)")
     .option("--image <base64>", "Token logo as base64-encoded data (max 2MB decoded)")
     .option("--image-url <url>", "Token logo URL")
+    .option("--description <text>", "Token description / project pitch")
     .option("--website <url>", "Website URL")
     .option("--twitter <url>", "Twitter link")
     .option("--telegram <url>", "Telegram link")
     .option("--slippage <n>", "Slippage tolerance (e.g. 0.01 = 1%)", parseFloat)
     .option("--auto-slippage", "Enable automatic slippage")
+    .option("--fee <amount>", "Base gas / fee")
     .option("--priority-fee <sol>", "Priority fee in SOL (SOL only)")
     .option("--tip-fee <amount>", "Tip fee")
     .option("--gas-price <amount>", "Gas price in wei (EVM chains)")
-    .option("--anti-mev", "Enable anti-MEV protection")
+    .option("--max-fee-per-gas <amount>", "Max fee per gas in wei (EVM only)")
+    .option("--max-priority-fee-per-gas <amount>", "Max priority fee per gas in wei (EVM only)")
+    .option("--anti-mev", "Enable anti-MEV protection (SOL only)")
+    .option("--anti-mev-mode <mode>", "Anti-MEV mode: normal / secure (SOL only)")
+    .option("--raised-token <symbol>", "Raise token symbol: pump→USDC; bonk→USD1; fourmeme→USDT/USD1; leave empty for native")
+    .option("--dev-wallet-bps <n>", "Dev wallet fee in basis points (100 = 1%)", parseInt)
+    .option("--dev-gas <amount>", "Dev gas amount")
+    .option("--dev-priority <amount>", "Dev priority fee")
+    .option("--dev-tip <amount>", "Dev tip fee")
+    .option("--dev-max-fee-per-gas <amount>", "Dev tx feeCap in wei (EVM EIP-1559)")
+    .option("--approve-vision <version>", "Approve vision version: v1 / v2 (default: v2)")
+    .option("--source <source>", "Traffic source identifier")
+    // Pump.fun specific
+    .option("--is-mayhem", "Enable Mayhem mode (Pump.fun only)")
+    .option("--is-cashback", "Enable Cashback (Pump.fun only)")
+    .option("--is-buy-back", "Enable Agent Auto Buyback (Pump.fun only)")
+    .option("--pump-fee-share-list <json>", "Pump.fun fee share list as JSON array (Pump.fun only)")
+    // Flap specific
+    .option("--flap-rate-conf <json>", "Flap rate config as JSON object (Flap only)")
+    // FourMeme specific
+    .option("--fourmeme-rate-conf <json>", "FourMeme rate config as JSON object (FourMeme only)")
+    // BAGS specific
+    .option("--bags-fee-share-list <json>", "BAGS fee share list as JSON array (BAGS only)")
+    // Bonk specific
+    .option("--bonk-model <model>", "Bonk model identifier (bonk DEX only)")
+    // Multi-wallet buy
+    .option("--buy-wallets <json>", "Multi-wallet buy config as JSON array [{from_address, buy_amt}]")
+    .option("--snip-buy-wallets <json>", "Snipe-buy wallet config as JSON array [{from_address, buy_amt}]")
+    .option("--interval-seconds <n>", "Interval between multi-wallet buys in seconds", parseInt)
+    // CondMarket execution config + auto-sell (JSON)
+    .option("--buy-trade-config <json>", "Buy-side trade config for CondMarket orders as JSON (TradeParam)")
+    .option("--sell-trade-config <json>", "Sell-side trade config for auto-sell / pending_sell as JSON (TradeParam)")
+    .option("--sell-configs <json>", "Auto-sell strategy list as JSON array (CookingSellConfig[])")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (!opts.image && !opts.imageUrl) {
@@ -58,15 +92,42 @@ export function registerCookingCommands(program: Command): void {
       };
       if (opts.image) params.image = opts.image;
       if (opts.imageUrl) params.image_url = opts.imageUrl;
+      if (opts.description) params.description = opts.description;
       if (opts.website) params.website = opts.website;
       if (opts.twitter) params.twitter = opts.twitter;
       if (opts.telegram) params.telegram = opts.telegram;
       if (opts.slippage != null) params.slippage = opts.slippage;
       if (opts.autoSlippage) params.auto_slippage = true;
+      if (opts.fee) params.fee = opts.fee;
       if (opts.priorityFee) params.priority_fee = opts.priorityFee;
       if (opts.tipFee) params.tip_fee = opts.tipFee;
       if (opts.gasPrice) params.gas_price = opts.gasPrice;
+      if (opts.maxFeePerGas) params.max_fee_per_gas = opts.maxFeePerGas;
+      if (opts.maxPriorityFeePerGas) params.max_priority_fee_per_gas = opts.maxPriorityFeePerGas;
       if (opts.antiMev) params.is_anti_mev = true;
+      if (opts.antiMevMode) params.anti_mev_mode = opts.antiMevMode;
+      if (opts.raisedToken != null) params.raised_token = opts.raisedToken;
+      if (opts.devWalletBps != null) params.dev_wallet_bps = opts.devWalletBps;
+      if (opts.devGas) params.dev_gas = opts.devGas;
+      if (opts.devPriority) params.dev_priority = opts.devPriority;
+      if (opts.devTip) params.dev_tip = opts.devTip;
+      if (opts.devMaxFeePerGas) params.dev_max_fee_per_gas = opts.devMaxFeePerGas;
+      if (opts.approveVision) params.approve_vision = opts.approveVision;
+      if (opts.source) params.source = opts.source;
+      if (opts.isMayhem) params.is_mayhem = true;
+      if (opts.isCashback) params.is_cashback = true;
+      if (opts.isBuyBack) params.is_buy_back = true;
+      if (opts.pumpFeeShareList) params.pump_fee_share_list = JSON.parse(opts.pumpFeeShareList);
+      if (opts.flapRateConf) params.flap_rate_conf = JSON.parse(opts.flapRateConf);
+      if (opts.fourmemeRateConf) params.fourmeme_rate_conf = JSON.parse(opts.fourmemeRateConf);
+      if (opts.bagsFeeShareList) params.bags_fee_share_list = JSON.parse(opts.bagsFeeShareList);
+      if (opts.bonkModel) params.bonk_model = opts.bonkModel;
+      if (opts.buyWallets) params.buy_wallets = JSON.parse(opts.buyWallets);
+      if (opts.snipBuyWallets) params.snip_buy_wallets = JSON.parse(opts.snipBuyWallets);
+      if (opts.intervalSeconds != null) params.interval_seconds = opts.intervalSeconds;
+      if (opts.buyTradeConfig) params.buy_trade_config = JSON.parse(opts.buyTradeConfig);
+      if (opts.sellTradeConfig) params.sell_trade_config = JSON.parse(opts.sellTradeConfig);
+      if (opts.sellConfigs) params.sell_configs = JSON.parse(opts.sellConfigs);
       const client = new OpenApiClient(getConfig(true));
       const data = await client.createToken(params).catch(exitOnError);
       printResult(data, opts.raw);


### PR DESCRIPTION
## Summary

Completes the `cooking create` advanced parameters end-to-end (CLI flags + client types + docs), so token launches can use the full `create_token` API surface beyond the basic fields.

This is a **parallel** PR to #144 — both add cooking advanced params. This branch is rebased on the latest `main` (1.3.7) and additionally fixes a field-name bug and trims params that the public API does not accept.

## What's added

- **Transaction / fee params**: `--fee`, `--dev-max-fee-per-gas`, `--anti-mev-mode`, `--raised-token`, `--dev-wallet-bps`, `--approve-vision`, `--source`, `--max-fee-per-gas`, `--max-priority-fee-per-gas`, `--description`
- **Fee-share configs (JSON)**: `--pump-fee-share-list`, `--bags-fee-share-list`, `--flap-rate-conf` (incl. V6 `buy_tax_rate` / `sell_tax_rate`), `--fourmeme-rate-conf`
- **Multi-wallet buy**: `--buy-wallets`, `--snip-buy-wallets`, `--interval-seconds`
- **CondMarket execution config**: `--buy-trade-config` / `--sell-trade-config` (TradeParam) — scoped to snipe/bundle/auto-sell orders, not the main creation tx
- **Auto-sell**: `--sell-configs` (CookingSellConfig[]) — delay-sell / limit-sell after launch
- **Pump.fun modes**: `--is-mayhem`, `--is-cashback`, `--is-buy-back` (Agent Auto Buyback)

## Fixes / cleanups

- **Fix** Flap `split_conf` field name: `split_bps` → `bps` (otherwise the split never applies)
- Pump fee-share `provider` restricted to `github` / `wallet` (dropped `twitter`)
- Dropped `is_revoke_fee_auth` and `is_agent` / `agent_bps`
- Dropped internal-only fields (`fourmeme_user_login_sign`, `is_approve_allowance`, `is_raised_swap`) — the public API does not accept them; the raise-token retry is handled server-side

## Docs

- `SKILL.md` and `cli-usage.md` updated with all flags, JSON schemas, and an Advanced API Fields section
- Guided launch flow made platform-aware (asks only the modes that exist on the chosen platform)
- Fee-share UX always collects shares as **percentages** and converts to bps internally

## Notes for reviewers (to confirm against backend)

- `--buy-amt` is treated as **human units** (e.g. `0.01` SOL), not lamports/wei
- `--slippage` uses the decimal convention `0.01 = 1%` (consistent with `swap`)
- `is_cashback` is documented as **Pump.fun only**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
