### PR TITLE
fix(portfolio): rename activity type values to camelCase

### DIFF
--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -186,7 +186,7 @@ gmgn-cli portfolio token-balance \
 | `--token <address>` | Filter by token |
 | `--limit <n>` | Page size |
 | `--cursor <cursor>` | Pagination cursor (pass the `next` value from the previous response) |
-| `--type <type>` | Repeatable: `buy` / `sell` / `add` / `remove` / `transfer` |
+| `--type <type>` | Repeatable: `buy` / `sell` / `transferIn` / `transferOut` / `add` / `remove` |
 
 The activity response includes a `next` field. Pass it to `--cursor` to fetch the next page.
 

--- a/src/commands/portfolio.ts
+++ b/src/commands/portfolio.ts
@@ -51,7 +51,7 @@ export function registerPortfolioCommands(program: Command): void {
     .option("--token <address>", "Filter by token contract address")
     .option("--limit <n>", "Page size", parseInt)
     .option("--cursor <cursor>", "Pagination cursor")
-    .option("--type <type...>", "Activity type filter, repeatable: buy / sell / add / remove / transfer")
+    .option("--type <type...>", "Activity type filter, repeatable: buy / sell / transferIn / transferOut / add / remove")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       validateChain(opts.chain);


### PR DESCRIPTION
- Rename transfer_in/transfer_out → transferIn/transferOut in portfolio activity --type filter
- Update SKILL.md and portfolio.ts help text to reflect new enum values