### PR TITLE
fix(cooking): correct pump fee-share provider values

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -784,7 +784,7 @@ gmgn-cli cooking create \
 | `--is-mayhem` | No | Enable Mayhem mode (**Pump.fun only**) |
 | `--is-cashback` | No | Enable Cashback (**Pump.fun only**) |
 | `--is-buy-back` | No | Enable Agent Auto Buyback (**Pump.fun only**) |
-| `--pump-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"github","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
+| `--pump-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
 | `--flap-rate-conf` | No | Rate config as JSON object (**Flap only**) |
 | `--fourmeme-rate-conf` | No | Rate config as JSON object (**FourMeme only**) |
 | `--bags-fee-share-list` | No | Fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**BAGS only**) |

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -163,7 +163,7 @@ gmgn-cli cooking stats [--raw]
 | `--is-mayhem` | No | Enable Mayhem mode (**Pump.fun only**) |
 | `--is-cashback` | No | Enable Cashback (**Pump.fun only**) |
 | `--is-buy-back` | No | Enable Agent Auto Buyback (**Pump.fun only**) |
-| `--pump-fee-share-list` | No | Pump.fun fee share list as JSON array: `[{"provider":"github","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
+| `--pump-fee-share-list` | No | Pump.fun fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**Pump.fun only**) |
 | `--flap-rate-conf` | No | Flap rate config as JSON object (**Flap only**) |
 | `--fourmeme-rate-conf` | No | FourMeme rate config as JSON object (**FourMeme only**) |
 | `--bags-fee-share-list` | No | BAGS fee share list as JSON array: `[{"provider":"twitter","username":"<handle>","basic_points":<n>}]` (**BAGS only**) |
@@ -206,11 +206,11 @@ Never set a fee-share split without the user's explicit instruction — it perma
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `provider` | string | Yes | `github` / `wallet` |
-| `username` | string | Yes | Username for `github`; a SOL address when `wallet` |
+| `provider` | string | Yes | `solana` / `twitter` / `github` |
+| `username` | string | Yes | Platform username; a SOL address when `provider` = `solana` |
 | `basic_points` | int | Yes | Share in bps — all entries must sum to **10000** |
 
-Example: `--pump-fee-share-list '[{"provider":"github","username":"handle","basic_points":10000}]'`
+Example: `--pump-fee-share-list '[{"provider":"twitter","username":"handle","basic_points":10000}]'`
 
 ### Bonk (`--dex bonk`)
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -171,8 +171,8 @@ export interface TokenSignalGroup {
 }
 
 export interface PumpFeeShareInfo {
-  provider: string;       // "github" | "wallet"
-  username: string;       // username for github; a SOL address when wallet
+  provider: string;       // "solana" | "twitter" | "github"
+  username: string;       // platform username; a SOL address when provider = "solana"
   basic_points: number;
 }
 


### PR DESCRIPTION
## Summary

Fixes the `pump_fee_share_list` `provider` values. The previously documented `wallet` value is rejected by the backend with **`unknown provider: wallet`**. The valid providers are **`solana` / `twitter` / `github`**.

## Changes

- `OpenApiClient.ts` — update `PumpFeeShareInfo.provider` comment to `solana / twitter / github`; `username` is a SOL address when `provider = solana`
- `SKILL.md` — provider enum and JSON-schema example corrected; flag-table example uses a valid provider
- `cli-usage.md` — `--pump-fee-share-list` example uses a valid provider

No behavior change in code (provider is a free-form string passed through); this corrects the documented/allowed values so users don't hit `unknown provider: wallet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
