### PR TITLE
feat(swap): add smart_trade order type to order strategy create

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -608,14 +608,17 @@ gmgn-cli order strategy create \
   --from <wallet_address> \
   --base-token <base_token_address> \
   --quote-token <quote_token_address> \
-  --order-type <limit_order> \
-  --sub-order-type <buy_low|buy_high|stop_loss|take_profit> \
-  --check-price <price> \
+  --order-type <limit_order|smart_trade> \
+  --sub-order-type <buy_low|buy_high|stop_loss|take_profit|mix_trade> \
+  [--check-price <price>] \
+  [--open-price <price>] \
   [--amount-in <amount> | --amount-in-percent <pct>] \
   [--slippage <n> | --auto-slippage] \
   [--limit-price-mode <exact|slippage>] \
   [--expire-in <seconds>] \
   [--sell-ratio-type <buy_amount|hold_amount>] \
+  [--quote-investment <amount>] \
+  [--condition-orders <json>] \
   [--priority-fee <sol>] \
   [--tip-fee <amount>] \
   [--gas-price <gwei>] \
@@ -625,18 +628,21 @@ gmgn-cli order strategy create \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | Base token contract address |
 | `--quote-token` | Yes | Quote token contract address |
-| `--order-type` | Yes | Order type: `limit_order` |
-| `--sub-order-type` | Yes | Sub-order type: `buy_low` / `buy_high` / `stop_loss` / `take_profit` |
-| `--check-price` | Yes | Trigger check price |
+| `--order-type` | Yes | Order type: `limit_order` / `smart_trade` |
+| `--sub-order-type` | Yes | `limit_order`: `buy_low` / `buy_high` / `stop_loss` / `take_profit`; `smart_trade` with condition_orders: `mix_trade` |
+| `--check-price` | No* | Trigger check price — required for `limit_order`; omit for `smart_trade` (trigger is in the `buy_low` condition order) |
+| `--open-price` | No | Open price of the position |
 | `--amount-in` | No* | Input amount (smallest unit); required unless `--amount-in-percent` is used |
 | `--amount-in-percent` | No* | Input as percentage (e.g. `50` = 50%); required unless `--amount-in` is used |
 | `--limit-price-mode` | No | `exact` / `slippage` (default: `slippage`) |
 | `--expire-in` | No | Order expiry in seconds |
 | `--sell-ratio-type` | No | `buy_amount` (default) / `hold_amount` |
+| `--quote-investment` | No | Quote token investment amount (`smart_trade`) |
+| `--condition-orders` | No | JSON array of condition sub-orders for `smart_trade`. Must include one `buy_low` entry (with `check_price` lower than `open_price`) plus at least one TP/SL entry |
 | `--slippage` | No | Slippage tolerance, e.g. `0.01` = 1% |
 | `--auto-slippage` | No | Enable automatic slippage |
 | `--priority-fee` | No | Priority fee in SOL (**required for SOL chain**) |
@@ -730,7 +736,6 @@ gmgn-cli cooking create \
   --buy-amt <amount> \
   [--image <base64> | --image-url <url>] \
   [--slippage <n> | --auto-slippage] \
-  [--description <text>] \
   [--website <url>] [--twitter <url>] [--telegram <url>] \
   [--fee <amount>] [--priority-fee <sol>] [--tip-fee <amount>] [--gas-price <amount>] \
   [--max-fee-per-gas <amount>] [--max-priority-fee-per-gas <amount>] \
@@ -761,7 +766,6 @@ gmgn-cli cooking create \
 | `--image-url` | No* | Token logo URL; required unless `--image` is used |
 | `--slippage` | No* | Slippage tolerance, e.g. `0.01` = 1%; required unless `--auto-slippage` is used |
 | `--auto-slippage` | No* | Enable automatic slippage; required unless `--slippage` is used |
-| `--description` | No | Token description / project pitch |
 | `--website` | No | Website URL |
 | `--twitter` | No | Twitter link |
 | `--telegram` | No | Telegram link |

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-swap
 description: "[FINANCIAL EXECUTION] Buy and sell meme coins and crypto tokens on Solana, BSC, Base, or Ethereum — single swap, multi-wallet batch trading, limit orders, stop loss, take profit, trailing stop loss, trailing take profit via GMGN API. Requires explicit user confirmation. Use when user asks to buy, sell, or swap a token, trade from multiple wallets, set a limit order, stop loss, take profit, or check order status."
-argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>] | [gas-price --chain <eth|bsc|base|sol>] | [order strategy list --chain <chain> --group-tag <LimitOrder|STMix>] | [order strategy create --chain <chain> --order-type limit_order --sub-order-type <buy_low|buy_high|stop_loss|take_profit> ...]"
+argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>] | [gas-price --chain <eth|bsc|base|sol>] | [order strategy list --chain <chain> --group-tag <LimitOrder|STMix>] | [order strategy create --chain <chain> --order-type <limit_order|smart_trade> --sub-order-type <buy_low|buy_high|stop_loss|take_profit|mix_trade> ...]"
 metadata:
   cliHelp: "gmgn-cli swap --help"
 ---
@@ -512,7 +512,7 @@ All fields are omitempty — fields unsupported by a chain are omitted. Units ar
 ## `order strategy create` Usage
 
 ```bash
-# Create a take-profit order: sell when price rises to target
+# Create a take-profit order: sell when price rises to target (limit_order)
 gmgn-cli order strategy create \
   --chain sol \
   --from <wallet_address> \
@@ -524,7 +524,7 @@ gmgn-cli order strategy create \
   --amount-in 1000000 \
   --slippage 0.01
 
-# Create a stop-loss order: sell when price drops to target
+# Create a stop-loss order: sell when price drops to target (limit_order)
 gmgn-cli order strategy create \
   --chain sol \
   --from <wallet_address> \
@@ -535,6 +535,19 @@ gmgn-cli order strategy create \
   --check-price 0.0005 \
   --amount-in-percent 100 \
   --slippage 0.01
+
+# Create a smart_trade with buy_low entry + take-profit + stop-loss (smart_trade)
+gmgn-cli order strategy create \
+  --chain sol \
+  --from <wallet_address> \
+  --base-token <token_address> \
+  --quote-token <sol_address> \
+  --order-type smart_trade \
+  --sub-order-type mix_trade \
+  --open-price 0.000082 \
+  --amount-in 1000000 \
+  --slippage 0.01 \
+  --condition-orders '[{"order_type":"buy_low","side":"buy","check_price":"0.00008"},{"order_type":"profit_stop","side":"sell","price_scale":"100","sell_ratio":"50"},{"order_type":"loss_stop","side":"sell","price_scale":"50","sell_ratio":"100"}]'
 ```
 
 ## `order strategy create` Parameters
@@ -545,14 +558,16 @@ gmgn-cli order strategy create \
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | all | Base token contract address |
 | `--quote-token` | Yes | all | Quote token contract address |
-| `--order-type` | Yes | all | Order type: `limit_order` |
-| `--sub-order-type` | Yes | all | Sub-order type: `buy_low` / `buy_high` / `stop_loss` / `take_profit` |
-| `--check-price` | Yes | all | Trigger price in USD — the order fires when the token's USD price crosses this value |
+| `--order-type` | Yes | all | Order type: `limit_order` / `smart_trade` |
+| `--sub-order-type` | Yes | all | `limit_order`: `buy_low` / `buy_high` / `stop_loss` / `take_profit`; `smart_trade` with condition_orders: `mix_trade` |
+| `--check-price` | No* | all | Trigger price — required for `limit_order`; omit for `smart_trade` (trigger is in the `buy_low` condition order) |
+| `--open-price` | No | all | Open price of the position |
 | `--amount-in` | No* | all | Input amount (smallest unit). Mutually exclusive with `--amount-in-percent` |
 | `--amount-in-percent` | No* | all | Input as percentage (e.g. `50` = 50%). Mutually exclusive with `--amount-in` |
 | `--limit-price-mode` | No | all | `exact` / `slippage` (default: `slippage`) |
 | `--expire-in` | No | all | Order expiry in seconds |
 | `--sell-ratio-type` | No | all | `buy_amount` (default) — when triggered, sells a fixed token amount stored at strategy creation time; `hold_amount` — when triggered, sells a fixed percentage of the position held at trigger time |
+| `--quote-investment` | No | all | Quote token investment amount (`smart_trade`) |
 | `--slippage` | No | all | Slippage tolerance, e.g. `0.01` = 1%. Mutually exclusive with `--auto-slippage` |
 | `--auto-slippage` | No | all | Enable automatic slippage |
 | `--priority-fee` | No | `sol` | Priority fee in SOL (≥ 0.00001). **Required** for SOL. |
@@ -563,6 +578,7 @@ gmgn-cli order strategy create \
 | `--max-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max fee per gas. Clamped per chain minimums. |
 | `--max-priority-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max priority fee per gas. Clamped per chain minimums; capped to `--max-fee-per-gas`. |
 | `--anti-mev` | No | sol / bsc / eth | Enable anti-MEV protection. Not supported on `base`. |
+| `--condition-orders` | No | all | JSON array of condition sub-orders for `smart_trade`. Must include one `buy_low` entry (with `check_price` lower than `open_price`) plus at least one TP/SL entry. |
 
 ### `order strategy create` Response Fields
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -127,7 +127,7 @@ export interface StrategyCreateParams {
   quote_token: string;
   order_type: string;
   sub_order_type: string;
-  check_price: string;
+  check_price?: string;
   open_price?: string;
   amount_in?: string;
   amount_in_percent?: string;
@@ -148,6 +148,8 @@ export interface StrategyCreateParams {
   priority_fee?: string;
   tip_fee?: string;
   custom_rpc?: string;
+  condition_orders?: StrategyConditionOrder[];
+  quote_investment?: string;
 }
 
 export interface StrategyCancelParams {

--- a/src/commands/swap.ts
+++ b/src/commands/swap.ts
@@ -203,14 +203,16 @@ export function registerSwapCommands(program: Command): void {
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--base-token <address>", "Base token contract address")
     .requiredOption("--quote-token <address>", "Quote token contract address")
-    .requiredOption("--order-type <type>", "Order type: limit_order")
-    .requiredOption("--sub-order-type <type>", "Sub-order type: buy_low / buy_high / stop_loss / take_profit")
-    .requiredOption("--check-price <price>", "Trigger check price")
+    .requiredOption("--order-type <type>", "Order type: limit_order / smart_trade")
+    .requiredOption("--sub-order-type <type>", "Sub-order type: buy_low / buy_high / stop_loss / take_profit (limit_order); mix_trade (smart_trade with condition_orders)")
+    .option("--check-price <price>", "Trigger check price (required for limit_order; omit for smart_trade)")
+    .option("--open-price <price>", "Open price of the position")
     .option("--amount-in <amount>", "Input amount (smallest unit)")
     .option("--amount-in-percent <pct>", "Input amount as a percentage (e.g. 50 = 50%)")
     .option("--limit-price-mode <mode>", "Price mode: exact / slippage (default: slippage)")
     .option("--expire-in <seconds>", "Order expiry in seconds", parseInt)
     .option("--sell-ratio-type <type>", "Sell ratio basis: buy_amount (default) / hold_amount")
+    .option("--quote-investment <amount>", "Quote token investment amount (smart_trade)")
     .option("--slippage <n>", "Slippage tolerance (e.g. 0.01 = 1%)", parseFloat)
     .option("--auto-slippage", "Enable automatic slippage")
     .option("--priority-fee <sol>", "Priority fee in SOL (required for SOL chain)")
@@ -221,6 +223,7 @@ export function registerSwapCommands(program: Command): void {
     .option("--max-fee-per-gas <amount>", "EIP-1559 max fee per gas (BSC / BASE / ETH)")
     .option("--max-priority-fee-per-gas <amount>", "EIP-1559 max priority fee per gas (BSC / BASE / ETH)")
     .option("--anti-mev", "Enable anti-MEV protection")
+    .option("--condition-orders <json>", "JSON array of condition sub-orders for smart_trade (must include a buy_low entry + TP/SL entries)")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (!opts.amountIn && !opts.amountInPercent) {
@@ -239,13 +242,15 @@ export function registerSwapCommands(program: Command): void {
         quote_token: opts.quoteToken,
         order_type: opts.orderType,
         sub_order_type: opts.subOrderType,
-        check_price: opts.checkPrice,
       };
+      if (opts.checkPrice) params.check_price = opts.checkPrice;
+      if (opts.openPrice) params.open_price = opts.openPrice;
       if (opts.amountIn) params.amount_in = opts.amountIn;
       if (opts.amountInPercent) params.amount_in_percent = opts.amountInPercent;
       if (opts.limitPriceMode) params.limit_price_mode = opts.limitPriceMode;
       if (opts.expireIn != null) params.expire_in = opts.expireIn;
       if (opts.sellRatioType) params.sell_ratio_type = opts.sellRatioType;
+      if (opts.quoteInvestment) params.quote_investment = opts.quoteInvestment;
       if (opts.slippage != null) params.slippage = opts.slippage;
       if (opts.autoSlippage) params.auto_slippage = true;
       if (opts.priorityFee) params.priority_fee = opts.priorityFee;
@@ -256,6 +261,10 @@ export function registerSwapCommands(program: Command): void {
       if (opts.maxFeePerGas) params.max_fee_per_gas = opts.maxFeePerGas;
       if (opts.maxPriorityFeePerGas) params.max_priority_fee_per_gas = opts.maxPriorityFeePerGas;
       if (opts.antiMev) params.is_anti_mev = true;
+      if (opts.conditionOrders) {
+        try { params.condition_orders = JSON.parse(opts.conditionOrders); }
+        catch { console.error("[gmgn-cli] --condition-orders must be valid JSON"); process.exit(1); }
+      }
       const client = new OpenApiClient(getConfig(true));
       const data = await client.createStrategyOrder(params).catch(exitOnError);
       printResult(data, opts.raw);


### PR DESCRIPTION
- Add --order-type smart_trade and --sub-order-type mix_trade support
- Make --check-price optional (required for limit_order, omitted for smart_trade)
- Add --open-price, --quote-investment, --condition-orders options
- Update StrategyCreateParams interface: check_price optional, add condition_orders/quote_investment
- Update SKILL.md and cli-usage.md docs with smart_trade examples and parameter table