### PR TITLE
fix(cooking): remove deprecated --interval-seconds flag

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -749,7 +749,7 @@ gmgn-cli cooking create \
   [--fourmeme-rate-conf <json>] \
   [--bags-fee-share-list <json>] \
   [--bonk-model <model>] \
-  [--buy-wallets <json>] [--snip-buy-wallets <json>] [--interval-seconds <n>] \
+  [--buy-wallets <json>] [--snip-buy-wallets <json>] \
   [--buy-trade-config <json>] [--sell-trade-config <json>] [--sell-configs <json>] \
   [--raw]
 ```
@@ -795,7 +795,6 @@ gmgn-cli cooking create \
 | `--bonk-model` | No | Bonk model identifier (**bonk DEX only**) |
 | `--buy-wallets` | No | Multi-wallet buy config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
 | `--snip-buy-wallets` | No | Snipe-buy wallet config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
-| `--interval-seconds` | No | Interval between multi-wallet buys in seconds |
 | `--buy-trade-config` | No | Buy-side trade config for CondMarket orders as JSON (TradeParam) |
 | `--sell-trade-config` | No | Sell-side trade config for auto-sell / pending_sell as JSON (TradeParam) |
 | `--sell-configs` | No | Auto-sell strategy list as JSON array (CookingSellConfig[]): `[{"sell_type":"delay_sell","delay_sec":<n>,"sell_ratio":"0.5","wallet_addresses":["<addr>"]}]` |

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -180,7 +180,6 @@ gmgn-cli cooking stats [--raw]
 | `--bonk-model` | No | Bonk model identifier (**bonk DEX only**) |
 | `--buy-wallets` | No | Multi-wallet buy config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
 | `--snip-buy-wallets` | No | Snipe-buy wallet config as JSON array: `[{"from_address":"<addr>","buy_amt":"<n>"}]` |
-| `--interval-seconds` | No | Interval between multi-wallet buys in seconds |
 | `--buy-trade-config` | No | Buy-side trade config for CondMarket orders as JSON (TradeParam) — see Advanced API Fields |
 | `--sell-trade-config` | No | Sell-side trade config for auto-sell / pending_sell as JSON (TradeParam) — see Advanced API Fields |
 | `--sell-configs` | No | Auto-sell strategy list as JSON array (CookingSellConfig[]) — see Auto-Sell Configuration |

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -314,7 +314,6 @@ export interface CreateTokenParams {
   // Multi-wallet buy
   buy_wallets?: BuyWalletInfo[];
   snip_buy_wallets?: BuyWalletInfo[];
-  interval_seconds?: number;
 }
 
 export class OpenApiClient {

--- a/src/commands/cooking.ts
+++ b/src/commands/cooking.ts
@@ -66,7 +66,6 @@ export function registerCookingCommands(program: Command): void {
     // Multi-wallet buy
     .option("--buy-wallets <json>", "Multi-wallet buy config as JSON array [{from_address, buy_amt}]")
     .option("--snip-buy-wallets <json>", "Snipe-buy wallet config as JSON array [{from_address, buy_amt}]")
-    .option("--interval-seconds <n>", "Interval between multi-wallet buys in seconds", parseInt)
     // CondMarket execution config + auto-sell (JSON)
     .option("--buy-trade-config <json>", "Buy-side trade config for CondMarket orders as JSON (TradeParam)")
     .option("--sell-trade-config <json>", "Sell-side trade config for auto-sell / pending_sell as JSON (TradeParam)")
@@ -124,7 +123,6 @@ export function registerCookingCommands(program: Command): void {
       if (opts.bonkModel) params.bonk_model = opts.bonkModel;
       if (opts.buyWallets) params.buy_wallets = JSON.parse(opts.buyWallets);
       if (opts.snipBuyWallets) params.snip_buy_wallets = JSON.parse(opts.snipBuyWallets);
-      if (opts.intervalSeconds != null) params.interval_seconds = opts.intervalSeconds;
       if (opts.buyTradeConfig) params.buy_trade_config = JSON.parse(opts.buyTradeConfig);
       if (opts.sellTradeConfig) params.sell_trade_config = JSON.parse(opts.sellTradeConfig);
       if (opts.sellConfigs) params.sell_configs = JSON.parse(opts.sellConfigs);


### PR DESCRIPTION
## Summary

Removes the deprecated `--interval-seconds` flag from `cooking create`. The `interval_seconds` param is no longer used.

## Changes

- `src/commands/cooking.ts` — drop the `--interval-seconds` option and its params assembly
- `src/client/OpenApiClient.ts` — drop `interval_seconds` from `CreateTokenParams`
- `skills/gmgn-cooking/SKILL.md` / `docs/cli-usage.md` — drop the flag from the parameter tables and usage block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
