### PR TITLE
feat(market): sync CLI with new market features — 30s kline, eth trenches, trending range filters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -461,6 +461,13 @@ gmgn-cli market trending \
   --order-by volume --limit 20 \
   --filter not_risk --filter not_honeypot
 
+# Trending with numeric range filters (min_*/max_* are forwarded as query params)
+gmgn-cli market trending \
+  --chain sol --interval 1h \
+  --min-liquidity 10000 --max-liquidity 1000000 \
+  --max-created 30m --min-smart-degen-count 1 \
+  --order-by volume --limit 30
+
 gmgn-cli market trenches \
   --chain sol \
   --type new_creation --type near_completion --type completed \

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -491,6 +491,13 @@ gmgn-cli market trending \
   --order-by volume --limit 20 \
   --filter not_risk --filter not_honeypot
 
+# 热门榜 + 数值范围过滤（min_*/max_* 以查询参数透传）
+gmgn-cli market trending \
+  --chain sol --interval 1h \
+  --min-liquidity 10000 --max-liquidity 1000000 \
+  --max-created 30m --min-smart-degen-count 1 \
+  --order-by volume --limit 30
+
 # 战壕新币列表
 gmgn-cli market trenches \
   --chain sol \

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -101,7 +101,7 @@ npx gmgn-cli market kline \
 |--------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` / `base` |
 | `--address` | Yes | Token contract address |
-| `--resolution` | Yes | Candlestick resolution: `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
+| `--resolution` | Yes | Candlestick resolution: `30s` / `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
 | `--from` | No | Start time (Unix seconds) |
 | `--to` | No | End time (Unix seconds) |
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -139,6 +139,8 @@ npx gmgn-cli market trending \
 
 **`base` platforms:** `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik`
 
+**`eth` platforms:** `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr`
+
 ---
 
 ## portfolio holdings
@@ -289,7 +291,7 @@ npx gmgn-cli market trenches --chain <chain> [--type <type...>] [--launchpad-pla
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
 | `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
 | `--limit` | No | Max results per category, max 80 (default: 80) |

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -134,7 +134,7 @@ npx gmgn-cli market trending \
 | `--filter` | No | Filter tag (repeatable): `has_social` / `not_risk` / `not_honeypot` / `verified` / `locked` / `renounced` / `distributed` / `frozen` / `burn` / `token_burnt` / `creator_hold` / `creator_close` / `creator_add_liquidity` / `creator_remove_liquidity` / `creator_sell` / `creator_buy` / `not_wash_trading` / `not_social_dup` / `not_image_dup` / `is_internal_market` / `is_out_market`. The gmgn web client also sends aliases `social_not_duplicate` / `img_not_duplicate` / `is_burnt` / `launching` / `migrated`, which are accepted but only the canonical tags change behavior. |
 | `--platform` | No | Platform filter (repeatable). Omit (or pass an empty list) to include **all** platforms. Available values depend on chain — see below. |
 | `--min-<metric>` / `--max-<metric>` | No | Numeric range filters (inclusive). Supported metrics: `volume` / `liquidity` / `marketcap` / `history-highest-marketcap` / `swaps` / `holder-count` / `gas-fee` / `renowned-count` / `smart-degen-count` / `bot-degen-count` / `visiting-count` / `price-change-percent` / `insider-rate` / `bundler-rate` / `entrapment-ratio` / `top10-holder-rate` / `top70-sniper-hold-rate` / `dev-team-hold-rate`. Unknown metrics are ignored by the service. |
-| `--min-created` / `--max-created` | No | Token-age window, duration string (`1m` / `6h` / `7d`). `--min-created` is a minimum age (excludes younger tokens); `--max-created` a maximum age (excludes older tokens). |
+| `--min-created` / `--max-created` | No | Token-age window, duration string with a `m` (minutes) / `h` (hours) / `d` (days) suffix, e.g. `30m` / `6h` / `7d`. `--min-created` is a minimum age (excludes younger tokens); `--max-created` a maximum age (excludes older tokens). The raw upstream rank interface accepts minutes only; the openapi-service does not forward this field — it evaluates the age window itself (cutoff = now − duration, native for `m`/`h`/`d`), so `6h`/`7d` work here. A bare number with no unit suffix is not accepted. |
 
 **`sol` platforms:** `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`
 
@@ -296,8 +296,16 @@ npx gmgn-cli market trenches --chain <chain> [--type <type...>] [--launchpad-pla
 |--------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
-| `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
+| `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain). Values depend on chain — see below. |
 | `--limit` | No | Max results per category, max 80 (default: 80) |
+
+**`sol` platforms:** `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `ray_launchpad` / `meteora_virtual_curve` / `xstocks`
+
+**`bsc` platforms:** `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun`
+
+**`base` platforms:** `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik`
+
+**`eth` platforms:** `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr`
 
 **Response:** `data.new_creation`, `data.pump`, `data.completed` — each is an array of `RankItem` (same structure as `market trending` rank items). **Note: `data.pump` in the response corresponds to `--type near_completion` in the request. The API always returns this category under the key `pump`, not `near_completion`.**
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -120,18 +120,21 @@ npx gmgn-cli market trending \
   [--direction asc|desc] \
   [--filter <tag>] \
   [--platform <name>] \
+  [--min-<metric> <n>] [--max-<metric> <n>] \
   [--raw]
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
-| `--interval` | Yes | `1h` / `3h` / `6h` / `24h` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--interval` | Yes | `1m` / `5m` / `1h` / `6h` / `24h` |
 | `--limit` | No | Number of results (default 100, max 100) |
 | `--order-by` | No | Sort field: `volume` / `swaps` / `liquidity` / `marketcap` / `holders` / `price` / `change` / `change1m` / `change5m` / `change1h` / `renowned_count` / `smart_degen_count` / `bluechip_owner_percentage` / `rank` / `creation_timestamp` / `square_mentions` / `history_highest_market_cap` / `gas_fee` |
 | `--direction` | No | Sort direction: `asc` / `desc` (default `desc`) |
-| `--filter` | No | Filter tag (repeatable): `has_social` / `not_risk` / `not_honeypot` / `verified` / `locked` / `renounced` / `distributed` / `frozen` / `burn` / `token_burnt` / `creator_hold` / `creator_close` / `creator_add_liquidity` / `creator_remove_liquidity` / `creator_sell` / `creator_buy` / `not_wash_trading` / `not_social_dup` / `not_image_dup` / `is_internal_market` / `is_out_market` |
+| `--filter` | No | Filter tag (repeatable): `has_social` / `not_risk` / `not_honeypot` / `verified` / `locked` / `renounced` / `distributed` / `frozen` / `burn` / `token_burnt` / `creator_hold` / `creator_close` / `creator_add_liquidity` / `creator_remove_liquidity` / `creator_sell` / `creator_buy` / `not_wash_trading` / `not_social_dup` / `not_image_dup` / `is_internal_market` / `is_out_market`. The gmgn web client also sends aliases `social_not_duplicate` / `img_not_duplicate` / `is_burnt` / `launching` / `migrated`, which are accepted but only the canonical tags change behavior. |
 | `--platform` | No | Platform filter (repeatable). Omit (or pass an empty list) to include **all** platforms. Available values depend on chain — see below. |
+| `--min-<metric>` / `--max-<metric>` | No | Numeric range filters (inclusive). Supported metrics: `volume` / `liquidity` / `marketcap` / `history-highest-marketcap` / `swaps` / `holder-count` / `gas-fee` / `renowned-count` / `smart-degen-count` / `bot-degen-count` / `visiting-count` / `price-change-percent` / `insider-rate` / `bundler-rate` / `entrapment-ratio` / `top10-holder-rate` / `top70-sniper-hold-rate` / `dev-team-hold-rate`. Unknown metrics are ignored by the service. |
+| `--min-created` / `--max-created` | No | Token-age window, duration string (`1m` / `6h` / `7d`). `--min-created` is a minimum age (excludes younger tokens); `--max-created` a maximum age (excludes older tokens). |
 
 **`sol` platforms:** `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -146,6 +146,32 @@ The response is an object with a `list` array. Each element in `list` is one can
 | `--filter <tag...>` | Repeatable filter tags (chain-specific). **⚠️ SOL defaults: `renounced frozen`; BSC/Base/ETH defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — chain defaults always apply. **sol** tags: `renounced` / `frozen` / `burn` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `not_wash_trading` / `is_internal_market` / `is_out_market`. **evm** tags: `not_honeypot` / `verified` / `renounced` / `locked` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `is_internal_market` / `is_out_market` |
 | `--platform <name...>` | Repeatable platform filter (chain-specific). **sol**: `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`. **bsc**: `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` / `pool_uniswap` / `pool_pancake`. **base**: `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik`. **eth**: `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
 
+### `market trending` Range Filters
+
+Optional `--min-*` / `--max-*` flags apply server-side numeric range filtering (inclusive). Unknown metrics are ignored by the service.
+
+| Option | Description |
+|--------|-------------|
+| `--min-volume` / `--max-volume` | Trading volume (USD) |
+| `--min-liquidity` / `--max-liquidity` | Liquidity (USD) |
+| `--min-marketcap` / `--max-marketcap` | Market cap (USD) |
+| `--min-history-highest-marketcap` / `--max-history-highest-marketcap` | Historical highest market cap (USD) |
+| `--min-swaps` / `--max-swaps` | Swap count |
+| `--min-holder-count` / `--max-holder-count` | Holder count |
+| `--min-gas-fee` / `--max-gas-fee` | Gas fee |
+| `--min-renowned-count` / `--max-renowned-count` | KOL / renowned wallet count |
+| `--min-smart-degen-count` / `--max-smart-degen-count` | Smart-money holder count |
+| `--min-bot-degen-count` / `--max-bot-degen-count` | Bot-degen wallet count |
+| `--min-visiting-count` / `--max-visiting-count` | Visitor count |
+| `--min-price-change-percent` / `--max-price-change-percent` | Price change ratio over the interval |
+| `--min-insider-rate` / `--max-insider-rate` | Insider trading ratio (0–1); tokens lacking this field are excluded |
+| `--min-bundler-rate` / `--max-bundler-rate` | Bundle-bot trading ratio (0–1); tokens lacking this field are excluded |
+| `--min-entrapment-ratio` / `--max-entrapment-ratio` | Entrapment trading ratio (0–1); tokens lacking this field are excluded |
+| `--min-top10-holder-rate` / `--max-top10-holder-rate` | Top-10 holder concentration (0–1) |
+| `--min-top70-sniper-hold-rate` / `--max-top70-sniper-hold-rate` | Top-70 sniper holding ratio (0–1) |
+| `--min-dev-team-hold-rate` / `--max-dev-team-hold-rate` | Dev-team holding ratio (0–1); `--min-dev-team-hold-rate` also excludes creator-close tokens |
+| `--min-created` / `--max-created` | Token age window, duration string `1m` / `6h` / `7d`. `--min-created` is a minimum age (excludes younger tokens); `--max-created` a maximum age (excludes older tokens) |
+
 ## Usage Examples
 
 ### Kline
@@ -275,6 +301,28 @@ gmgn-cli market trending \
   --chain eth --interval 24h \
   --filter not_honeypot --filter verified \
   --order-by smart_degen_count --limit 20 --raw
+```
+
+### Trending — Numeric Range Filters
+
+```bash
+# SOL 1h trending — liquidity 10k–1M, market cap above 50k, sorted by volume
+gmgn-cli market trending \
+  --chain sol --interval 1h \
+  --min-liquidity 10000 --max-liquidity 1000000 --min-marketcap 50000 \
+  --order-by volume --limit 30 --raw
+
+# SOL 5m hottest — fresh tokens (under 30 min old) with smart money interest
+gmgn-cli market trending \
+  --chain sol --interval 5m \
+  --max-created 30m --min-smart-degen-count 1 \
+  --order-by volume --limit 50 --raw
+
+# SOL 1h trending — exclude high-insider / high-bundler tokens
+gmgn-cli market trending \
+  --chain sol --interval 1h \
+  --max-insider-rate 0.3 --max-bundler-rate 0.3 \
+  --order-by volume --limit 20 --raw
 ```
 
 ### Trending — Base by Launchpad Platform

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -170,7 +170,7 @@ Optional `--min-*` / `--max-*` flags apply server-side numeric range filtering (
 | `--min-top10-holder-rate` / `--max-top10-holder-rate` | Top-10 holder concentration (0–1) |
 | `--min-top70-sniper-hold-rate` / `--max-top70-sniper-hold-rate` | Top-70 sniper holding ratio (0–1) |
 | `--min-dev-team-hold-rate` / `--max-dev-team-hold-rate` | Dev-team holding ratio (0–1); `--min-dev-team-hold-rate` also excludes creator-close tokens |
-| `--min-created` / `--max-created` | Token age window, duration string `1m` / `6h` / `7d`. `--min-created` is a minimum age (excludes younger tokens); `--max-created` a maximum age (excludes older tokens) |
+| `--min-created` / `--max-created` | Token age window, duration string with a `m` (minutes) / `h` (hours) / `d` (days) suffix, e.g. `30m` / `6h` / `7d`. `--min-created` is a minimum age (excludes younger tokens); `--max-created` a maximum age (excludes older tokens). **Note:** the raw upstream rank interface accepts minutes only; the openapi-service does not forward this field — it evaluates the age window itself (cutoff = now − duration, computed natively for `m`/`h`/`d`), so `6h` / `7d` work here. Always include a unit suffix — a bare number is **not** accepted. |
 
 ## Usage Examples
 
@@ -284,15 +284,23 @@ gmgn-cli market trending \
   --order-by volume --limit 20 --raw
 ```
 
-### Trending — ETH (No Platform Filter)
+### Trending — ETH by Launchpad Platform
 
 ```bash
-# ETH 1h trending — all tokens, sorted by volume
+# ETH 1h trending — all platforms, sorted by volume
 gmgn-cli market trending --chain eth --interval 1h --order-by volume --limit 20
 
-# ETH 1h trending — with safety filters
+# ETH 1h trending — specific platforms only
 gmgn-cli market trending \
   --chain eth --interval 1h \
+  --platform trench --platform clanker --platform klik \
+  --order-by volume --limit 50 --raw
+
+# ETH 1h trending — all ETH platforms with safety filters
+gmgn-cli market trending \
+  --chain eth --interval 1h \
+  --platform trench --platform clanker --platform klik --platform livo --platform stroid \
+  --platform pool_uniswap_v2 --platform pool_uniswap_v3 --platform printr \
   --filter not_honeypot --filter verified \
   --order-by volume --limit 20 --raw
 
@@ -552,6 +560,15 @@ Use field combinations to determine what stage a token is in. This affects how s
 | `--sort-by` | No | Client-side sort per category: `smart_degen_count` / `renowned_count` / `volume_24h` / `volume_1h` / `swaps_24h` / `swaps_1h` / `rug_ratio` / `holder_count` / `usd_market_cap` / `created_timestamp` |
 | `--direction` | No | Sort direction: `asc` / `desc` (default: `desc`; `asc` for `rug_ratio`) |
 | `--min-*` / `--max-*` | No | Server-side filter range flags — see Filter Fields Reference below |
+
+**`--launchpad-platform` values by chain** (omit `--launchpad-platform` to use all of the chain's platforms):
+
+| Chain | Platforms |
+|-------|-----------|
+| `sol`  | `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `ray_launchpad` / `meteora_virtual_curve` / `xstocks` |
+| `bsc`  | `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` |
+| `base` | `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik` |
+| `eth`  | `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
 
 ### Filter Presets
 
@@ -850,6 +867,28 @@ gmgn-cli market trenches --chain base --raw \
 gmgn-cli market trenches --chain base --raw \
   --type completed \
   --launchpad-platform clanker --launchpad-platform bankr --launchpad-platform flaunch --launchpad-platform zora --launchpad-platform zora_creator --launchpad-platform baseapp --launchpad-platform basememe --launchpad-platform virtuals_v2 --launchpad-platform klik \
+  --limit 80
+```
+
+### ETH Trenches Examples
+
+```bash
+# All three categories at once
+gmgn-cli market trenches --chain eth --raw \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform trench --launchpad-platform clanker --launchpad-platform klik --launchpad-platform livo --launchpad-platform stroid --launchpad-platform pool_uniswap_v2 --launchpad-platform pool_uniswap_v3 --launchpad-platform printr \
+  --limit 80
+
+# New creation only
+gmgn-cli market trenches --chain eth --raw \
+  --type new_creation \
+  --launchpad-platform trench --launchpad-platform clanker --launchpad-platform klik --launchpad-platform livo --launchpad-platform stroid --launchpad-platform pool_uniswap_v2 --launchpad-platform pool_uniswap_v3 --launchpad-platform printr \
+  --limit 80
+
+# Completed (open market) only
+gmgn-cli market trenches --chain eth --raw \
+  --type completed \
+  --launchpad-platform trench --launchpad-platform clanker --launchpad-platform klik --launchpad-platform livo --launchpad-platform stroid --launchpad-platform pool_uniswap_v2 --launchpad-platform pool_uniswap_v3 --launchpad-platform printr \
   --limit 80
 ```
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-market
 description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, and newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks for price chart, trending tokens, what's pumping, hot coins, new launches, token signals, or wants to discover early-stage opportunities.
-argument-hint: "kline --chain <sol|bsc|base|eth> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base> | signal --chain <sol|bsc>"
+argument-hint: "kline --chain <sol|bsc|base|eth> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth> | signal --chain <sol|bsc>"
 metadata:
   cliHelp: "gmgn-cli market --help"
 ---
@@ -52,7 +52,7 @@ Use the `gmgn-cli` tool to query K-line data for a token, browse trending tokens
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` (kline / trending only; trenches: `sol` / `bsc` / `base`; signal: `sol` / `bsc` only)
+`sol` / `bsc` / `base` / `eth` (kline / trending / trenches; signal: `sol` / `bsc` only)
 
 ## Prerequisites
 
@@ -144,7 +144,7 @@ The response is an object with a `list` array. Each element in `list` is one can
 | `--order-by <field>` | Sort field: `default` / `swaps` / `marketcap` / `history_highest_market_cap` / `liquidity` / `volume` / `holder_count` / `smart_degen_count` / `renowned_count` / `gas_fee` / `price` / `change1m` / `change5m` / `change1h` / `creation_timestamp` |
 | `--direction <asc\|desc>` | Sort direction (default `desc`) |
 | `--filter <tag...>` | Repeatable filter tags (chain-specific). **⚠️ SOL defaults: `renounced frozen`; BSC/Base/ETH defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — chain defaults always apply. **sol** tags: `renounced` / `frozen` / `burn` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `not_wash_trading` / `is_internal_market` / `is_out_market`. **evm** tags: `not_honeypot` / `verified` / `renounced` / `locked` / `token_burnt` / `has_social` / `not_social_dup` / `not_image_dup` / `dexscr_update_link` / `is_internal_market` / `is_out_market` |
-| `--platform <name...>` | Repeatable platform filter (chain-specific). **sol**: `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`. **bsc**: `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` / `pool_uniswap` / `pool_pancake`. **base**: `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik`. **eth**: no platform filter (omit `--platform` for ETH) |
+| `--platform <name...>` | Repeatable platform filter (chain-specific). **sol**: `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `xstocks` / `ray_launchpad` / `meteora_virtual_curve` / `pool_ray` / `pool_meteora` / `pool_pump_amm` / `pool_orca`. **bsc**: `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` / `pool_uniswap` / `pool_pancake`. **base**: `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik`. **eth**: `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
 
 ## Usage Examples
 
@@ -496,7 +496,7 @@ Use field combinations to determine what stage a token is in. This affects how s
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
 | `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
 | `--limit` | No | Max results per category, max 80 (default: 80) |

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-market
 description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, and newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks for price chart, trending tokens, what's pumping, hot coins, new launches, token signals, or wants to discover early-stage opportunities.
-argument-hint: "kline --chain <sol|bsc|base|eth> --address <token_address> --resolution <1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base> | signal --chain <sol|bsc>"
+argument-hint: "kline --chain <sol|bsc|base|eth> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base> | signal --chain <sol|bsc>"
 metadata:
   cliHelp: "gmgn-cli market --help"
 ---
@@ -97,7 +97,7 @@ When a request returns `429`:
 |-----------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
 | `--address` | Yes | Token contract address |
-| `--resolution` | Yes | Candlestick resolution: `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
+| `--resolution` | Yes | Candlestick resolution: `30s` / `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
 | `--from` | No | Start time (Unix seconds) |
 | `--to` | No | End time (Unix seconds) |
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -820,12 +820,17 @@ const TRENCHES_PLATFORMS: Record<string, string[]> = {
     "clanker", "bankr", "flaunch", "zora", "zora_creator",
     "baseapp", "basememe", "virtuals_v2", "klik",
   ],
+  eth: [
+    "trench", "clanker", "klik", "livo", "stroid",
+    "pool_uniswap_v2", "pool_uniswap_v3", "printr",
+  ],
 };
 
 const TRENCHES_QUOTE_ADDRESS_TYPES: Record<string, number[]> = {
   sol:  [4, 5, 3, 1, 13, 0],
   bsc:  [6, 7, 1, 16, 8, 3, 9, 10, 2, 17, 18, 0],
   base: [11, 3, 12, 13, 0],
+  eth:  [20, 11, 8, 3, 12, 1, 0],
 };
 
 function buildTrenchesBody(chain: string, types?: string[], platforms?: string[], limit?: number, filters?: Record<string, number | string>): Record<string, unknown> {

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -57,7 +57,7 @@ export function registerMarketCommands(program: Command): void {
     .option("--order-by <field>", "Sort field: default / volume / swaps / marketcap / holder_count / price / change1h / ... (see docs for full list)")
     .option("--direction <dir>", "Sort direction: asc / desc")
     .option("--filter <tag...>", "Filter tags, repeatable. sol: renounced / frozen / has_social / not_wash_trading / ... evm: not_honeypot / verified / renounced / locked / ... (see docs for full list)")
-    .option("--platform <name...>", "Platform filter, repeatable. sol: Pump.fun / letsbonk / moonshot_app / ... bsc: fourmeme / four_xmode_agent / cubepeg / likwid / goplus_creator / goplus_skills / openfour / flap / flap_stocks / flap_aioracle / clanker / ... base: clanker / flaunch / zora / ... (see docs for full list)")
+    .option("--platform <name...>", "Platform filter, repeatable. sol: Pump.fun / letsbonk / moonshot_app / ... bsc: fourmeme / four_xmode_agent / cubepeg / likwid / goplus_creator / goplus_skills / openfour / flap / flap_stocks / flap_aioracle / clanker / ... base: clanker / flaunch / zora / ... eth: trench / clanker / klik / livo / stroid / pool_uniswap_v2 / pool_uniswap_v3 / printr (see docs for full list)")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       validateChain(opts.chain);
@@ -76,7 +76,7 @@ export function registerMarketCommands(program: Command): void {
   const trenchesCmd = market
     .command("trenches")
     .description("Get Trenches token data (new creation, near completion, completed)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .option("--type <type...>", "Categories to query, repeatable: new_creation / near_completion / completed (default: all three)")
     .option("--launchpad-platform <platform...>", "Launchpad platform filter, repeatable (default: all platforms for the chain)")
     .option("--limit <n>", "Max results per category, max 80 (default: 80)", parseInt)

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -28,7 +28,7 @@ export function registerMarketCommands(program: Command): void {
     .description("Get token K-line (candlestick) data")
     .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
     .requiredOption("--address <address>", "Token contract address")
-    .requiredOption("--resolution <resolution>", "Candlestick resolution: 1m / 5m / 15m / 1h / 4h / 1d")
+    .requiredOption("--resolution <resolution>", "Candlestick resolution: 30s / 1m / 5m / 15m / 1h / 4h / 1d")
     .option("--from <timestamp>", "Start time (Unix seconds)", parseInt)
     .option("--to <timestamp>", "End time (Unix seconds)", parseInt)
     .option("--raw", "Output raw JSON")

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -48,7 +48,7 @@ export function registerMarketCommands(program: Command): void {
       printResult(data, opts.raw);
     });
 
-  market
+  const trendingCmd = market
     .command("trending")
     .description("Get trending token swap data")
     .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
@@ -58,20 +58,40 @@ export function registerMarketCommands(program: Command): void {
     .option("--direction <dir>", "Sort direction: asc / desc")
     .option("--filter <tag...>", "Filter tags, repeatable. sol: renounced / frozen / has_social / not_wash_trading / ... evm: not_honeypot / verified / renounced / locked / ... (see docs for full list)")
     .option("--platform <name...>", "Platform filter, repeatable. sol: Pump.fun / letsbonk / moonshot_app / ... bsc: fourmeme / four_xmode_agent / cubepeg / likwid / goplus_creator / goplus_skills / openfour / flap / flap_stocks / flap_aioracle / clanker / ... base: clanker / flaunch / zora / ... eth: trench / clanker / klik / livo / stroid / pool_uniswap_v2 / pool_uniswap_v3 / printr (see docs for full list)")
-    .option("--raw", "Output raw JSON")
-    .action(async (opts) => {
-      validateChain(opts.chain);
-      const extra: Record<string, string | number | string[]> = {};
-      if (opts.limit != null) extra["limit"] = opts.limit;
-      if (opts.orderBy) extra["order_by"] = opts.orderBy;
-      if (opts.direction) extra["direction"] = opts.direction;
-      if (opts.filter?.length) extra["filters"] = opts.filter;
-      if (opts.platform?.length) extra["platforms"] = opts.platform;
+    .option("--raw", "Output raw JSON");
 
-      const client = new OpenApiClient(getConfig());
-      const data = await client.getTrendingSwaps(opts.chain, opts.interval, extra).catch(exitOnError);
-      printResult(data, opts.raw);
-    });
+  // Dynamically register all server-side min_*/max_* range filter flags
+  for (const def of RANK_RANGE_FIELDS) {
+    const flag = def.api.replace(/_/g, "-");
+    if (def.type === "int") {
+      trendingCmd.option(`--${flag} <${def.type}>`, def.desc, parseInt);
+    } else if (def.type === "float") {
+      trendingCmd.option(`--${flag} <${def.type}>`, def.desc, parseFloat);
+    } else {
+      trendingCmd.option(`--${flag} <value>`, def.desc);
+    }
+  }
+
+  trendingCmd.action(async (opts) => {
+    validateChain(opts.chain);
+    const extra: Record<string, string | number | string[]> = {};
+    if (opts.limit != null) extra["limit"] = opts.limit;
+    if (opts.orderBy) extra["order_by"] = opts.orderBy;
+    if (opts.direction) extra["direction"] = opts.direction;
+    if (opts.filter?.length) extra["filters"] = opts.filter;
+    if (opts.platform?.length) extra["platforms"] = opts.platform;
+
+    // Apply server-side min_*/max_* range filters
+    const optsMap = opts as Record<string, unknown>;
+    for (const def of RANK_RANGE_FIELDS) {
+      const val = optsMap[apiFieldToCliKey(def.api)];
+      if (val != null) extra[def.api] = val as string | number;
+    }
+
+    const client = new OpenApiClient(getConfig());
+    const data = await client.getTrendingSwaps(opts.chain, opts.interval, extra).catch(exitOnError);
+    printResult(data, opts.raw);
+  });
 
   const trenchesCmd = market
     .command("trenches")
@@ -268,6 +288,52 @@ const TRENCHES_FILTER_FIELDS: TrenchesFilterField[] = [
   { api: "max_twitter_rename_count",  type: "int",   desc: "Max Twitter rename count" },
   { api: "min_tg_call_count",         type: "int",   desc: "Min Telegram call count" },
   { api: "max_tg_call_count",         type: "int",   desc: "Max Telegram call count" },
+];
+
+// Server-side numeric range filters for `market trending` (/v1/market/rank).
+// Passed through as min_<metric>/max_<metric> query params; the service applies the
+// metrics it understands and ignores the rest. min_created/max_created are token-age
+// windows expressed as duration strings (e.g. 1m / 6h / 7d) — note these use m/h/d,
+// NOT the s/m form used by trenches; min_created is a minimum age, max_created a maximum.
+const RANK_RANGE_FIELDS: TrenchesFilterField[] = [
+  { api: "min_volume",                    type: "float", desc: "Min trading volume (USD)" },
+  { api: "max_volume",                    type: "float", desc: "Max trading volume (USD)" },
+  { api: "min_liquidity",                 type: "float", desc: "Min liquidity (USD)" },
+  { api: "max_liquidity",                 type: "float", desc: "Max liquidity (USD)" },
+  { api: "min_marketcap",                 type: "float", desc: "Min market cap (USD)" },
+  { api: "max_marketcap",                 type: "float", desc: "Max market cap (USD)" },
+  { api: "min_history_highest_marketcap", type: "float", desc: "Min historical highest market cap (USD)" },
+  { api: "max_history_highest_marketcap", type: "float", desc: "Max historical highest market cap (USD)" },
+  { api: "min_swaps",                     type: "int",   desc: "Min swap count" },
+  { api: "max_swaps",                     type: "int",   desc: "Max swap count" },
+  { api: "min_holder_count",              type: "int",   desc: "Min holder count" },
+  { api: "max_holder_count",              type: "int",   desc: "Max holder count" },
+  { api: "min_gas_fee",                   type: "float", desc: "Min gas fee" },
+  { api: "max_gas_fee",                   type: "float", desc: "Max gas fee" },
+  { api: "min_renowned_count",            type: "int",   desc: "Min KOL / renowned wallet count" },
+  { api: "max_renowned_count",            type: "int",   desc: "Max KOL / renowned wallet count" },
+  { api: "min_smart_degen_count",         type: "int",   desc: "Min smart-money holder count" },
+  { api: "max_smart_degen_count",         type: "int",   desc: "Max smart-money holder count" },
+  { api: "min_bot_degen_count",           type: "int",   desc: "Min bot-degen wallet count" },
+  { api: "max_bot_degen_count",           type: "int",   desc: "Max bot-degen wallet count" },
+  { api: "min_visiting_count",            type: "int",   desc: "Min visitor count" },
+  { api: "max_visiting_count",            type: "int",   desc: "Max visitor count" },
+  { api: "min_price_change_percent",      type: "float", desc: "Min price change ratio over the interval" },
+  { api: "max_price_change_percent",      type: "float", desc: "Max price change ratio over the interval" },
+  { api: "min_insider_rate",              type: "float", desc: "Min insider trading ratio (0–1); tokens lacking this field are excluded" },
+  { api: "max_insider_rate",              type: "float", desc: "Max insider trading ratio (0–1); tokens lacking this field are excluded" },
+  { api: "min_bundler_rate",              type: "float", desc: "Min bundle-bot trading ratio (0–1); tokens lacking this field are excluded" },
+  { api: "max_bundler_rate",              type: "float", desc: "Max bundle-bot trading ratio (0–1); tokens lacking this field are excluded" },
+  { api: "min_entrapment_ratio",          type: "float", desc: "Min entrapment trading ratio (0–1); tokens lacking this field are excluded" },
+  { api: "max_entrapment_ratio",          type: "float", desc: "Max entrapment trading ratio (0–1); tokens lacking this field are excluded" },
+  { api: "min_top10_holder_rate",         type: "float", desc: "Min top-10 holder concentration (0–1)" },
+  { api: "max_top10_holder_rate",         type: "float", desc: "Max top-10 holder concentration (0–1)" },
+  { api: "min_top70_sniper_hold_rate",    type: "float", desc: "Min top-70 sniper holding ratio (0–1)" },
+  { api: "max_top70_sniper_hold_rate",    type: "float", desc: "Max top-70 sniper holding ratio (0–1)" },
+  { api: "min_dev_team_hold_rate",        type: "float", desc: "Min dev-team holding ratio (0–1); also excludes creator-close tokens" },
+  { api: "max_dev_team_hold_rate",        type: "float", desc: "Max dev-team holding ratio (0–1)" },
+  { api: "min_created",                   type: "string", desc: "Min token age (minimum age), duration string e.g. 1m / 6h / 7d" },
+  { api: "max_created",                   type: "string", desc: "Max token age (maximum age), duration string e.g. 600m / 24h" },
 ];
 
 // Named filter presets using actual server-side API field names

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -293,8 +293,12 @@ const TRENCHES_FILTER_FIELDS: TrenchesFilterField[] = [
 // Server-side numeric range filters for `market trending` (/v1/market/rank).
 // Passed through as min_<metric>/max_<metric> query params; the service applies the
 // metrics it understands and ignores the rest. min_created/max_created are token-age
-// windows expressed as duration strings (e.g. 1m / 6h / 7d) — note these use m/h/d,
+// windows expressed as duration strings (e.g. 30m / 6h / 7d) — note these use m/h/d,
 // NOT the s/m form used by trenches; min_created is a minimum age, max_created a maximum.
+// The raw upstream rank interface accepts minutes only; the openapi-service does not
+// forward this field — it evaluates the age window itself (cutoff = now - duration,
+// native for m/h/d), so h/d are valid through this CLI. Passed through verbatim
+// (string); a bare number with no unit suffix is rejected.
 const RANK_RANGE_FIELDS: TrenchesFilterField[] = [
   { api: "min_volume",                    type: "float", desc: "Min trading volume (USD)" },
   { api: "max_volume",                    type: "float", desc: "Max trading volume (USD)" },
@@ -332,8 +336,8 @@ const RANK_RANGE_FIELDS: TrenchesFilterField[] = [
   { api: "max_top70_sniper_hold_rate",    type: "float", desc: "Max top-70 sniper holding ratio (0–1)" },
   { api: "min_dev_team_hold_rate",        type: "float", desc: "Min dev-team holding ratio (0–1); also excludes creator-close tokens" },
   { api: "max_dev_team_hold_rate",        type: "float", desc: "Max dev-team holding ratio (0–1)" },
-  { api: "min_created",                   type: "string", desc: "Min token age (minimum age), duration string e.g. 1m / 6h / 7d" },
-  { api: "max_created",                   type: "string", desc: "Max token age (maximum age), duration string e.g. 600m / 24h" },
+  { api: "min_created",                   type: "string", desc: "Min token age (minimum age). Duration with unit suffix m/h/d, e.g. 30m / 6h / 7d (h/d evaluated server-side; raw upstream takes minutes only). A bare number with no unit is rejected." },
+  { api: "max_created",                   type: "string", desc: "Max token age (maximum age). Duration with unit suffix m/h/d, e.g. 600m / 24h (h/d evaluated server-side; raw upstream takes minutes only). A bare number with no unit is rejected." },
 ];
 
 // Named filter presets using actual server-side API field names


### PR DESCRIPTION
## Summary

Syncs the `gmgn-cli` market commands with three new capabilities added to
gmgn-openapi-service:

- **`market kline` — 30s resolution.** Adds `30s` to the `--resolution` options.
- **`market trenches` — ETH support.** Allows `--chain eth` and adds the ETH
  launchpad platforms/quote-address types so trenches returns data on ETH.
- **`market trending` — numeric range filters.** Adds dynamic `--min-*`/`--max-*`
  flags (18 metrics + `--min-created`/`--max-created` token-age windows), forwarded
  as `min_<metric>`/`max_<metric>` query params to `/v1/market/rank`.

## Changes

| Command | Change |
| ------- | ------ |
| `market kline` | `--resolution` now accepts `30s` |
| `market trenches` | `--chain eth` supported; ETH platforms in `TRENCHES_PLATFORMS` / `TRENCHES_QUOTE_ADDRESS_TYPES` |
| `market trending` | `--min-*` / `--max-*` range filters via `RANK_RANGE_FIELDS` (volume, liquidity, marketcap, holders, smart/renowned counts, insider/bundler/entrapment rates, created window, etc.) |

Docs synced in lockstep per the repo rule: `SKILL.md`, `docs/cli-usage.md`,
`Readme.md`, and `Readme.zh.md`.

## Notes

- Range-filter wire format is unchanged from existing flags — `--min-liquidity 1000`
  just adds `min_liquidity=1000` to the query, like `--filter`/`--platform` already do.
  Service applies the metrics it understands and ignores the rest.
- `--min-created`/`--max-created` use `m`/`h`/`d` duration strings (not the `s`/`m`
  form used by `trenches`); `--min-created` = minimum age, `--max-created` = maximum age.
- No breaking changes; all additions are backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
