### PR TITLE
feat(chain): add robinhood support; disable monad/megaeth/hyperevm/tron

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "gmgn-cli",
-  "description": "GMGN OpenAPI skills for AI coding assistants — token info, market data, wallet portfolio, and swap execution across sol / bsc / base / eth / monad",
+  "description": "GMGN OpenAPI skills for AI coding assistants — token info, market data, wallet portfolio, and swap execution across sol / bsc / base / eth / robinhood",
   "owner": {
     "name": "GMGN"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gmgn-cli",
-  "description": "GMGN OpenAPI skills — token info, market data, wallet portfolio, and swap execution across sol / bsc / base / eth / monad",
+  "description": "GMGN OpenAPI skills — token info, market data, wallet portfolio, and swap execution across sol / bsc / base / eth / robinhood",
   "version": "1.0.0",
   "author": {
     "name": "GMGN"

--- a/Readme.md
+++ b/Readme.md
@@ -726,9 +726,11 @@ gmgn-cli cooking \
 
 | Commands | Chains | Chain Currencies |
 |----------|--------|-----------------|
-| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` | — |
-| swap / order | `sol` / `bsc` / `base` / `eth` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC · eth: ETH |
-| gas-price | `sol` / `bsc` / `base` / `eth` | — |
+| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
+| swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC · eth: ETH |
+| gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
+| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` (kol/smartmoney) · `sol` / `bsc` (signal) — **no `robinhood`** | — |
+| cooking create | `sol` / `bsc` / `base` — **no `robinhood`** | — |
 
 ---
 

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -750,9 +750,11 @@ gmgn-cli cooking \
 
 | 接口类型 | 支持的链 | 链原生货币 |
 |----------|----------|-----------|
-| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` | — |
-| swap / order | `sol` / `bsc` / `base` / `eth` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC · eth: ETH |
-| gas-price | `sol` / `bsc` / `base` / `eth` | — |
+| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
+| swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC · eth: ETH |
+| gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
+| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth`（kol/smartmoney）· `sol` / `bsc`（signal）— **不支持 `robinhood`** | — |
+| cooking create | `sol` / `bsc` / `base` — **不支持 `robinhood`** | — |
 
 ---
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -367,7 +367,7 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 Query the hot-search ranking — the most-searched tokens, ranked by `visiting_count` (search heat). Cross-chain top-500; one request can cover several chains at once. API Key auth only.
 
 ```bash
-# Default 4-chain set (sol/bsc/base/eth, each 24h):
+# Default 5-chain set (sol/bsc/base/eth/robinhood, each 24h):
 gmgn-cli market hot-searches [--raw]
 
 # Specific chain(s) and interval:
@@ -379,7 +379,7 @@ gmgn-cli market hot-searches --params '<json_array>' [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | Repeatable: `sol` / `bsc` / `base` / `eth` / `robinhood`. Omit for the default 4-chain set. |
+| `--chain` | No | Repeatable: `sol` / `bsc` / `base` / `eth` / `robinhood`. Omit for the default 5-chain set. |
 | `--interval` | No | `1m` / `5m` / `1h` / `6h` / `24h` (default `24h`). Applies to every `--chain`. |
 | `--limit` | No | Max results per chain (default `500`). |
 | `--filter` | No | Repeatable **boolean** filter tags (downstream `filter.filters`). sol defaults: `renounced` / `frozen`; EVM defaults: `not_honeypot` / `verified` / `renounced`. Recognised tags: `renounced` / `frozen` (sol) / `is_burnt` / `token_burnt` / `not_wash_trading` / `not_honeypot` (EVM) / `verified` (EVM) / `locked` (EVM) / `has_social` / `distribed` / `not_risk` / `img_not_duplicate` / `social_not_duplicate` / `creator_hold` / `creator_close` / `dexscr_update_link` / `launching` / `migrated` / `hide_b20` (base) / `hide_non_b20` (base). Unknown tags are silent no-ops. |

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -126,7 +126,7 @@ npx gmgn-cli market trending \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--interval` | Yes | `1m` / `5m` / `1h` / `6h` / `24h` |
 | `--limit` | No | Number of results (default 100, max 100) |
 | `--order-by` | No | Sort field: `volume` / `swaps` / `liquidity` / `marketcap` / `holders` / `price` / `change` / `change1m` / `change5m` / `change1h` / `renowned_count` / `smart_degen_count` / `bluechip_owner_percentage` / `rank` / `creation_timestamp` / `square_mentions` / `history_highest_market_cap` / `gas_fee` |
@@ -294,7 +294,7 @@ npx gmgn-cli market trenches --chain <chain> [--type <type...>] [--launchpad-pla
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
 | `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain). Values depend on chain — see below. |
 | `--limit` | No | Max results per category, max 80 (default: 80) |
@@ -367,7 +367,7 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 Query the hot-search ranking — the most-searched tokens, ranked by `visiting_count` (search heat). Cross-chain top-500; one request can cover several chains at once. API Key auth only.
 
 ```bash
-# Default 7-chain set (sol/bsc/base/eth/hyperevm/megaeth/monad, each 24h):
+# Default 4-chain set (sol/bsc/base/eth, each 24h):
 gmgn-cli market hot-searches [--raw]
 
 # Specific chain(s) and interval:
@@ -379,7 +379,7 @@ gmgn-cli market hot-searches --params '<json_array>' [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | Repeatable: `sol` / `bsc` / `base` / `eth` / `monad` / `megaeth` / `hyperevm` / `tron`. Omit for the default 7-chain set. |
+| `--chain` | No | Repeatable: `sol` / `bsc` / `base` / `eth` / `robinhood`. Omit for the default 4-chain set. |
 | `--interval` | No | `1m` / `5m` / `1h` / `6h` / `24h` (default `24h`). Applies to every `--chain`. |
 | `--limit` | No | Max results per chain (default `500`). |
 | `--filter` | No | Repeatable **boolean** filter tags (downstream `filter.filters`). sol defaults: `renounced` / `frozen`; EVM defaults: `not_honeypot` / `verified` / `renounced`. Recognised tags: `renounced` / `frozen` (sol) / `is_burnt` / `token_burnt` / `not_wash_trading` / `not_honeypot` (EVM) / `verified` (EVM) / `locked` (EVM) / `has_social` / `distribed` / `not_risk` / `img_not_duplicate` / `social_not_duplicate` / `creator_hold` / `creator_close` / `dexscr_update_link` / `launching` / `migrated` / `hide_b20` (base) / `hide_non_b20` (base). Unknown tags are silent no-ops. |
@@ -408,7 +408,7 @@ gmgn-cli track follow-tokens \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--wallet` | Yes | Wallet address |
 | `--group-id` | No | `all_group` (all tokens), `default`, or a user-defined group ID |
 | `--interval` | No | Time interval for price change stats: `1m` / `5m` / `1h` / `6h` / `24h` |
@@ -433,7 +433,7 @@ gmgn-cli track follow-token-groups \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--wallet` | Yes | Wallet address |
 
 ---
@@ -562,7 +562,7 @@ npx gmgn-cli swap \
 
 | Option | Required | Chain | Description |
 |--------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--from` | Yes | all | Wallet address (must match the wallet bound to the API Key) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -639,7 +639,7 @@ gmgn-cli multi-swap \
 
 | Option | Required | Chain | Description |
 |--------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--accounts` | Yes | all | Comma-separated wallet addresses (1–100, all bound to API Key) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -682,7 +682,7 @@ npx gmgn-cli order get --chain <chain> --order-id <order_id> [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `monad` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--order-id` | Yes | Order ID (returned by the `swap` command) |
 
 **Response fields (data):** Same structure as the `swap` response above.
@@ -717,7 +717,7 @@ gmgn-cli order strategy create \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | Base token contract address |
 | `--quote-token` | Yes | Quote token contract address |

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-market
 description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.), and the hot-search ranking (most-searched tokens) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks for price chart, trending tokens, what's pumping, hot coins, most searched tokens, new launches, token signals, or wants to discover early-stage opportunities.
-argument-hint: "kline --chain <sol|bsc|base|eth> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth> | signal --chain <sol|bsc> | hot-searches [--chain <sol|bsc|base|eth|monad|megaeth|hyperevm|tron...>] [--interval <1m|5m|1h|6h|24h>]"
+argument-hint: "kline --chain <sol|bsc|base|eth|robinhood> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth|robinhood> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth|robinhood> | signal --chain <sol|bsc> | hot-searches [--chain <sol|bsc|base|eth|robinhood...>] [--interval <1m|5m|1h|6h|24h>]"
 metadata:
   cliHelp: "gmgn-cli market --help"
 ---
@@ -55,7 +55,7 @@ Use the `gmgn-cli` tool to query K-line data for a token, browse trending tokens
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` (kline / trending / trenches; signal: `sol` / `bsc` only; hot-searches: `sol` / `bsc` / `base` / `eth` / `monad` / `megaeth` / `hyperevm` / `tron`)
+`sol` / `bsc` / `base` / `eth` / `robinhood` (kline / trending / trenches; signal: `sol` / `bsc` only; hot-searches: `sol` / `bsc` / `base` / `eth` / `robinhood`)
 
 ## Prerequisites
 
@@ -85,7 +85,7 @@ When a request returns `429`:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--address` | Yes | Token contract address |
 | `--resolution` | Yes | Candlestick resolution: `30s` / `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
 | `--from` | No | Start time (Unix seconds) |
@@ -128,7 +128,7 @@ The response is an object with a `list` array. Each element in `list` is one can
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--interval` | Required. `1m` / `5m` / `1h` / `6h` / `24h` (default `1h`) |
 | `--limit <n>` | Number of results (default 100, max 100) |
 | `--order-by <field>` | Sort field: `default` / `swaps` / `marketcap` / `history_highest_market_cap` / `liquidity` / `volume` / `holder_count` / `smart_degen_count` / `renowned_count` / `gas_fee` / `price` / `change1m` / `change5m` / `change1h` / `creation_timestamp` |
@@ -542,7 +542,7 @@ Use field combinations to determine what stage a token is in. This affects how s
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
 | `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
 | `--limit` | No | Max results per category, max 80 (default: 80) |
@@ -1037,7 +1037,7 @@ Returns the hot-search ranking — the tokens people are searching for most righ
 
 | Option | Description |
 |--------|-------------|
-| `--chain <chain...>` | Repeatable. `sol` / `bsc` / `base` / `eth` / `monad` / `megaeth` / `hyperevm` / `tron`. **Omit to query the default 7-chain set** (sol / bsc / base / eth / hyperevm / megaeth / monad, each at `24h` with chain-appropriate safety filters). |
+| `--chain <chain...>` | Repeatable. `sol` / `bsc` / `base` / `eth` / `robinhood`. **Omit to query the default 4-chain set** (sol / bsc / base / eth, each at `24h` with chain-appropriate safety filters). |
 | `--interval <interval>` | `1m` / `5m` / `1h` / `6h` / `24h` (default `24h`). Applies to every `--chain` provided. |
 | `--limit <n>` | Max results per chain (default `500`). |
 | `--filter <tag...>` | Repeatable **boolean** filter tags (the downstream `filter.filters` array). **⚠️ SOL defaults: `renounced frozen`; EVM defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — the server applies chain defaults. See the Filter Tags table below for the exact vocabulary. |
@@ -1103,9 +1103,9 @@ Numeric bounds use the **same rank-style metric names as `market trending`**. Th
 
 **Notes on behaviour:**
 
-- `--chain all` is **not** valid. To aggregate across chains, pass `--chain` multiple times (or omit `--chain` for the default 7-chain set).
+- `--chain all` is **not** valid. To aggregate across chains, pass `--chain` multiple times (or omit `--chain` for the default 4-chain set).
 - When you pass `--chain` but omit `--filter`, the **server** applies the chain-appropriate default filters — so each chain is filtered even without an explicit `--filter`.
-- Different chains return different counts: a chain's token count depends on how many of its tokens made the global top-500 (sol is usually the largest; monad / megaeth are small).
+- Different chains return different counts: a chain's token count depends on how many of its tokens made the global top-500 (sol is usually the largest).
 
 ## `market hot-searches` Response Fields
 
@@ -1139,7 +1139,7 @@ See the [`market trending` Response Fields](#market-trending-response-fields) se
 ### `market hot-searches` Usage Examples
 
 ```bash
-# Default 7-chain hot-search ranking (sol/bsc/base/eth/hyperevm/megaeth/monad, each 24h)
+# Default 4-chain hot-search ranking (sol/bsc/base/eth, each 24h)
 gmgn-cli market hot-searches --raw
 
 # SOL only, 24h hot-search list

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1037,7 +1037,7 @@ Returns the hot-search ranking — the tokens people are searching for most righ
 
 | Option | Description |
 |--------|-------------|
-| `--chain <chain...>` | Repeatable. `sol` / `bsc` / `base` / `eth` / `robinhood`. **Omit to query the default 4-chain set** (sol / bsc / base / eth, each at `24h` with chain-appropriate safety filters). |
+| `--chain <chain...>` | Repeatable. `sol` / `bsc` / `base` / `eth` / `robinhood`. **Omit to query the default 5-chain set** (sol / bsc / base / eth / robinhood, each at `24h` with chain-appropriate safety filters). |
 | `--interval <interval>` | `1m` / `5m` / `1h` / `6h` / `24h` (default `24h`). Applies to every `--chain` provided. |
 | `--limit <n>` | Max results per chain (default `500`). |
 | `--filter <tag...>` | Repeatable **boolean** filter tags (the downstream `filter.filters` array). **⚠️ SOL defaults: `renounced frozen`; EVM defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — the server applies chain defaults. See the Filter Tags table below for the exact vocabulary. |
@@ -1103,7 +1103,7 @@ Numeric bounds use the **same rank-style metric names as `market trending`**. Th
 
 **Notes on behaviour:**
 
-- `--chain all` is **not** valid. To aggregate across chains, pass `--chain` multiple times (or omit `--chain` for the default 4-chain set).
+- `--chain all` is **not** valid. To aggregate across chains, pass `--chain` multiple times (or omit `--chain` for the default 5-chain set).
 - When you pass `--chain` but omit `--filter`, the **server** applies the chain-appropriate default filters — so each chain is filtered even without an explicit `--filter`.
 - Different chains return different counts: a chain's token count depends on how many of its tokens made the global top-500 (sol is usually the largest).
 
@@ -1139,7 +1139,7 @@ See the [`market trending` Response Fields](#market-trending-response-fields) se
 ### `market hot-searches` Usage Examples
 
 ```bash
-# Default 4-chain hot-search ranking (sol/bsc/base/eth, each 24h)
+# Default 5-chain hot-search ranking (sol/bsc/base/eth/robinhood, each 24h)
 gmgn-cli market hot-searches --raw
 
 # SOL only, 24h hot-search list
@@ -1182,7 +1182,7 @@ Present per chain, ranked by `visiting_count` (search heat):
 
 - `market kline`: `--from` and `--to` are Unix timestamps in **seconds** — CLI converts to milliseconds automatically
 - `market trending`: `--filter` and `--platform` are repeatable flags
-- `market hot-searches`: `--chain` and `--filter` are repeatable flags; omit `--chain` to query the default 7-chain set. `--min-*`/`--max-*` range flags reuse the same metric names as `market trending` and are translated server-side per `--interval`
+- `market hot-searches`: `--chain` and `--filter` are repeatable flags; omit `--chain` to query the default 5-chain set. `--min-*`/`--max-*` range flags reuse the same metric names as `market trending` and are translated server-side per `--interval`
 - All commands use exist auth (API Key only, no signature)
 - If the user doesn't provide kline timestamps, calculate them from the current time based on their desired time range
 - Use `--raw` to get single-line JSON for further processing

--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-portfolio
 description: Analyze any crypto wallet by address — holdings, realized/unrealized P&L, win rate, trading history, performance stats, specific token balance, and tokens created by a developer wallet (with ATH market cap and DEX graduation status) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks about a wallet's holdings, P&L, win rate, what tokens a dev has launched, the highest ATH token a dev ever created, or wants a wallet report to decide whether to copy-trade or follow.
-argument-hint: "<info|holdings|activity|stats|token-balance|created-tokens> [--chain <sol|bsc|base|eth>] [--wallet <wallet_address>]"
+argument-hint: "<info|holdings|activity|stats|token-balance|created-tokens> [--chain <sol|bsc|base|eth|robinhood>] [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli portfolio --help"
 ---
@@ -45,7 +45,7 @@ Use the `gmgn-cli` tool to query wallet portfolio data based on the user's reque
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth`
+`sol` / `bsc` / `base` / `eth` / `robinhood`
 
 ## Prerequisites
 

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -58,7 +58,7 @@ Use the `gmgn-cli` tool to submit a token swap or query an existing order. `GMGN
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth`
+`sol` / `bsc` / `base` / `eth` / `robinhood`
 
 ## Chain Currencies
 
@@ -154,7 +154,7 @@ gmgn-cli swap \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -372,7 +372,7 @@ gmgn-cli multi-swap \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--accounts` | Yes | all | Comma-separated wallet addresses (1–100, all must be bound to the API Key) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -539,7 +539,7 @@ gmgn-cli order strategy create \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | all | Base token contract address |
 | `--quote-token` | Yes | all | Quote token contract address |
@@ -596,7 +596,7 @@ gmgn-cli order strategy list --chain sol --group-tag STMix --base-token <token_a
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--type` | No | `open` (default) / `history` |
 | `--from` | No | Filter by wallet address |
 | `--group-tag` | Yes | Filter by order group: `LimitOrder` (limit orders only) / `STMix` (mixed strategy orders: take-profit, stop-loss, trailing take-profit, trailing stop-loss) |
@@ -620,7 +620,7 @@ gmgn-cli order strategy list --chain sol --group-tag STMix --base-token <token_a
 | `auto_slippage`            | bool   | Whether auto slippage is enabled |
 | `base_decimal`             | int    | Base token decimal places |
 | `base_token`               | string | Base token contract address |
-| `chain`                    | string | Chain: `sol` / `bsc` / `base` / `eth` |
+| `chain`                    | string | Chain: `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `close_amount`             | string | Token amount sold on close; empty when order is open |
 | `close_price`              | string | Token price at close; empty when order is open |
 | `close_sell_model`         | string | Sell model used on close; empty when order is open |
@@ -734,7 +734,7 @@ gmgn-cli order strategy cancel \
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--order-id` | Yes | Order ID to cancel |
 | `--order-type` | No | Order type: `limit_order` (limit order) / `smart_trade` (mixed strategy order: take-profit, stop-loss, trailing take-profit, trailing stop-loss) |

--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-token
 description: Research any crypto or meme token by address — real-time price, market cap, liquidity, holder list, trader list, top Smart Money and KOL positions, security audit (honeypot, rug pull risk, dev wallet, renounced status), social links (Twitter/X, website) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks about a token's price, safety, holders, traders, smart money exposure, or wants due diligence before buying.
-argument-hint: "<sub-command> --chain <sol|bsc|base|eth> --address <token_address>"
+argument-hint: "<sub-command> --chain <sol|bsc|base|eth|robinhood> --address <token_address>"
 metadata:
   cliHelp: "gmgn-cli token --help"
 ---
@@ -19,7 +19,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 ## Core Concepts
 
 - **Token address** — The on-chain contract address that uniquely identifies a token on its chain. Required for all token sub-commands. Format: base58 (SOL) or `0x...` hex (BSC/Base).
-- **Chain** — The blockchain network: `sol` = Solana, `bsc` = BNB Smart Chain, `base` = Base (Coinbase L2), `eth` = Ethereum mainnet.
+- **Chain** — The blockchain network: `sol` = Solana, `bsc` = BNB Smart Chain, `base` = Base (Coinbase L2), `eth` = Ethereum mainnet, `robinhood` = Robinhood chain.
 - **Market cap** — Not returned directly by `token info`. Calculate as `price.price × circulating_supply` (`price` is a nested object; use `price.price` for the current USD price string).
 - **Liquidity** — USD value of token reserves in the main trading pool. Low liquidity (< $10k) means high price impact / slippage when buying or selling.
 - **Holder** — A wallet that currently holds the token. `token holders` returns wallets ranked by current balance.
@@ -44,7 +44,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth`
+`sol` / `bsc` / `base` / `eth` / `robinhood`
 
 ## Prerequisites
 
@@ -74,7 +74,7 @@ When a request returns `429`:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--address` | Yes | Token contract address |
 | `--raw` | No | Output raw single-line JSON (for piping or further processing) |
 
@@ -82,7 +82,7 @@ When a request returns `429`:
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--chain` | Yes | — | `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Yes | — | `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--address` | Yes | — | Token contract address |
 | `--limit` | No | `20` | Number of results, max `100` |
 | `--order-by` | No | `amount_percentage` | Sort field — see table below |

--- a/skills/gmgn-track/SKILL.md
+++ b/skills/gmgn-track/SKILL.md
@@ -59,7 +59,9 @@ Use the `gmgn-cli` tool to query on-chain tracking data based on the user's requ
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth`
+`sol` / `bsc` / `base` / `eth` / `robinhood`
+
+Note: `track kol` and `track smartmoney` do **not** support `robinhood` — they accept `sol` / `bsc` / `base` / `eth` only.
 
 ## Prerequisites
 
@@ -130,7 +132,7 @@ gmgn-cli track smartmoney --chain sol --side sell --limit 10 --raw
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--wallet <address>` | Required. Wallet address to query |
 | `--group-id <id>` | Filter by group: `all_group` (all tokens across groups), `default` (default group), or a user-defined group ID |
 | `--interval <interval>` | Time interval for price change stats (e.g. `1m`, `5m`, `1h`, `6h`, `24h`) |
@@ -172,7 +174,7 @@ Each item in `followings` contains:
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--wallet <address>` | Required. Wallet address to query |
 
 ## `track follow-token-groups` Response Fields
@@ -190,7 +192,7 @@ Each item in `followings` contains:
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
 | `--wallet <address>` | Filter by wallet address |
 | `--limit <n>` | Page size (1–100, default 10) |
 | `--side <side>` | Trade direction: `buy` / `sell` |

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -187,7 +187,7 @@ export interface TokenSignalGroup {
 export interface HotSearchesParam {
   label?: string;
   interval: string;       // "1m" | "5m" | "1h" | "6h" | "24h"
-  chain: string;          // "sol" | "bsc" | "base" | "eth" | "monad" | "megaeth" | "hyperevm" | "tron"
+  chain: string;          // "sol" | "bsc" | "base" | "eth" | "robinhood"
   filters?: string[];
   limit?: number;
   [key: string]: string[] | number | string | undefined;

--- a/src/commands/cooking.ts
+++ b/src/commands/cooking.ts
@@ -81,6 +81,10 @@ export function registerCookingCommands(program: Command): void {
         process.exit(1);
       }
       validateChain(opts.chain);
+      if (opts.chain === "robinhood") {
+        console.error(`[gmgn-cli] cooking create does not support robinhood, got "${opts.chain}"`);
+        process.exit(1);
+      }
       const params: CreateTokenParams = {
         chain: opts.chain,
         dex: opts.dex,

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -26,7 +26,7 @@ export function registerMarketCommands(program: Command): void {
   market
     .command("kline")
     .description("Get token K-line (candlestick) data")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--address <address>", "Token contract address")
     .requiredOption("--resolution <resolution>", "Candlestick resolution: 30s / 1m / 5m / 15m / 1h / 4h / 1d")
     .option("--from <timestamp>", "Start time (Unix seconds)", parseInt)
@@ -51,7 +51,7 @@ export function registerMarketCommands(program: Command): void {
   const trendingCmd = market
     .command("trending")
     .description("Get trending token swap data")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--interval <interval>", "Time interval: 1m / 5m / 1h / 6h / 24h")
     .option("--limit <n>", "Number of results (default 100, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: default / volume / swaps / marketcap / holder_count / price / change1h / ... (see docs for full list)")
@@ -96,7 +96,7 @@ export function registerMarketCommands(program: Command): void {
   const trenchesCmd = market
     .command("trenches")
     .description("Get Trenches token data (new creation, near completion, completed)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .option("--type <type...>", "Categories to query, repeatable: new_creation / near_completion / completed (default: all three)")
     .option("--launchpad-platform <platform...>", "Launchpad platform filter, repeatable (default: all platforms for the chain)")
     .option("--limit <n>", "Max results per category, max 80 (default: 80)", parseInt)
@@ -207,7 +207,7 @@ export function registerMarketCommands(program: Command): void {
   const hotSearchesCmd = market
     .command("hot-searches")
     .description("Get the hot-search ranking (most-searched tokens) for one or more chains")
-    .option("--chain <chain...>", "Chain(s), repeatable: sol / bsc / base / eth / monad / megaeth / hyperevm / tron (default: all 7 chains)")
+    .option("--chain <chain...>", "Chain(s), repeatable: sol / bsc / base / eth / robinhood (default: all default chains)")
     .option("--interval <interval>", "Time window: 1m / 5m / 1h / 6h / 24h (default 24h)", "24h")
     .option("--limit <n>", "Max results per chain (default 500)", parseInt)
     .option("--filter <tag...>", "Boolean filter tags, repeatable. sol defaults: renounced / frozen; EVM defaults: not_honeypot / verified / renounced")

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -246,7 +246,7 @@ export function registerMarketCommands(program: Command): void {
         process.exit(1);
       }
     } else {
-      // Empty params lets the server apply its default 7-chain config. Filter fields
+      // Empty params lets the server apply its default 5-chain config. Filter fields
       // are flattened directly onto each param (no nested `filter` object).
       const optsMap = opts as Record<string, unknown>;
       const chains: string[] = opts.chain?.length ? (opts.chain as string[]) : [];

--- a/src/commands/portfolio.ts
+++ b/src/commands/portfolio.ts
@@ -10,7 +10,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("holdings")
     .description("Get wallet token holdings")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--limit <n>", "Page size (default 20, max 50)", parseInt, 20)
     .option("--cursor <cursor>", "Pagination cursor")
@@ -46,7 +46,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("activity")
     .description("Get wallet transaction activity")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--token <address>", "Filter by token contract address")
     .option("--limit <n>", "Page size", parseInt)
@@ -71,7 +71,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("stats")
     .description("Get wallet trading statistics (supports multiple wallets)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address...>", "Wallet address(es), repeatable")
     .option("--period <period>", "Stats period: 7d / 30d", "7d")
     .option("--raw", "Output raw JSON")
@@ -96,7 +96,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("token-balance")
     .description("Get wallet token balance for a single token")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address>", "Wallet address")
     .requiredOption("--token <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
@@ -112,7 +112,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("created-tokens")
     .description("Get tokens created by a developer wallet")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address>", "Developer wallet address")
     .option("--order-by <field>", "Sort field: market_cap / token_ath_mc")
     .option("--direction <dir>", "Sort direction: asc / desc")

--- a/src/commands/swap.ts
+++ b/src/commands/swap.ts
@@ -8,7 +8,7 @@ export function registerSwapCommands(program: Command): void {
   program
     .command("swap")
     .description("Submit a token swap")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -76,7 +76,7 @@ export function registerSwapCommands(program: Command): void {
   program
     .command("multi-swap")
     .description("Submit token swaps across multiple wallets concurrently (up to 100 wallets)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--accounts <addresses>", "Comma-separated wallet addresses (all must be bound to the API Key)")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -150,7 +150,7 @@ export function registerSwapCommands(program: Command): void {
   order
     .command("quote")
     .description("Get a swap quote without submitting a transaction (exist auth — GMGN_API_KEY only, no private key needed)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--from <address>", "Wallet address")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -173,7 +173,7 @@ export function registerSwapCommands(program: Command): void {
   order
     .command("get")
     .description("Query order status (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / monad")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--order-id <id>", "Order ID")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -185,8 +185,8 @@ export function registerSwapCommands(program: Command): void {
 
   program
     .command("gas-price")
-    .description("Query recommended gas price tiers for any chain (exist auth — API Key only; eth / bsc / base / sol)")
-    .requiredOption("--chain <chain>", "Chain: eth / bsc / base / sol")
+    .description("Query recommended gas price tiers for any chain (exist auth — API Key only; eth / bsc / base / sol / robinhood)")
+    .requiredOption("--chain <chain>", "Chain: eth / bsc / base / sol / robinhood")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       const client = new OpenApiClient(getConfig(false));
@@ -199,7 +199,7 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("create")
     .description("Create a limit/strategy order (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--base-token <address>", "Base token contract address")
     .requiredOption("--quote-token <address>", "Quote token contract address")
@@ -283,7 +283,7 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("list")
     .description("List strategy orders (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .option("--type <type>", "open (default) / history")
     .option("--from <address>", "Filter by wallet address")
     .option("--group-tag <tag>", "Filter by group: LimitOrder / STMix")
@@ -308,7 +308,7 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("cancel")
     .description("Cancel a strategy order (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--order-id <id>", "Order ID to cancel")
     .option("--order-type <type>", "Order type: limit_order / smart_trade")

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -10,7 +10,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("info")
     .description("Get token basic information and realtime price")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -24,7 +24,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("security")
     .description("Get token security metrics")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -38,7 +38,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("pool")
     .description("Get token liquidity pool information")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -52,7 +52,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("holders")
     .description("Get top token holders")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--address <address>", "Token contract address")
     .option("--limit <n>", "Number of results (default 20, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: amount_percentage / profit / unrealized_profit / buy_volume_cur / sell_volume_cur", "amount_percentage")
@@ -75,7 +75,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("traders")
     .description("Get top token traders")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--address <address>", "Token contract address")
     .option("--limit <n>", "Number of results (default 20, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: amount_percentage / profit / unrealized_profit / buy_volume_cur / sell_volume_cur", "amount_percentage")

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -10,7 +10,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-tokens")
     .description("Get the followed token list for a wallet on a given chain")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--group-id <id>", "Filter by group: all_group (all), default, or a user-defined group ID")
     .option("--interval <interval>", "Time interval for price change stats (e.g. 1m, 5m, 1h, 6h, 24h)")
@@ -38,7 +38,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-token-groups")
     .description("Get the follow token group names for a wallet on a given chain")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -51,7 +51,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-wallet")
     .description("Get follow-wallet trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .option("--wallet <address>", "Filter by wallet address")
     .option("--limit <n>", "Page size (1–100, default 10)", parseInt)
     .option("--side <side>", "Trade direction filter: buy / sell")
@@ -82,6 +82,10 @@ export function registerTrackCommands(program: Command): void {
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (opts.chain) validateChain(opts.chain);
+      if (opts.chain === "robinhood") {
+        console.error(`[gmgn-cli] track kol does not support robinhood, got "${opts.chain}"`);
+        process.exit(1);
+      }
       const client = new OpenApiClient(getConfig());
       const data = await client.getKol(opts.chain, opts.limit).catch(exitOnError) as { list?: { side: string }[] };
       if (opts.side && data?.list) {
@@ -99,6 +103,10 @@ export function registerTrackCommands(program: Command): void {
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (opts.chain) validateChain(opts.chain);
+      if (opts.chain === "robinhood") {
+        console.error(`[gmgn-cli] track smartmoney does not support robinhood, got "${opts.chain}"`);
+        process.exit(1);
+      }
       const client = new OpenApiClient(getConfig());
       const data = await client.getSmartMoney(opts.chain, opts.limit).catch(exitOnError) as { list?: { side: string }[] };
       if (opts.side && data?.list) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,4 +1,4 @@
-const VALID_CHAINS = new Set(["sol", "bsc", "base", "eth", "monad"]);
+const VALID_CHAINS = new Set(["sol", "bsc", "base", "eth", "robinhood" /*, "monad" */]);
 const SOL_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 const POSITIVE_INT_RE = /^\d+$/;
@@ -13,7 +13,7 @@ export function validateChain(chain: string): void {
 }
 
 export function validateAddress(address: string, chain: string, label: string): void {
-  const isEvm = chain === "bsc" || chain === "base" || chain === "eth" || chain === "monad";
+  const isEvm = chain === "bsc" || chain === "base" || chain === "eth" || chain === "robinhood" /* || chain === "monad" */;
   const valid = isEvm ? EVM_ADDRESS_RE.test(address) : SOL_ADDRESS_RE.test(address);
   if (!valid) {
     console.error(


### PR DESCRIPTION
Add robinhood as a supported chain across the CLI and skills, and stop advertising chains that are not publicly supported yet.

robinhood:
- validate.ts: add to VALID_CHAINS and treat as EVM for address checks
- reject guards for commands that do not support it: track kol, track smartmoney, cooking create (mirrors market signal)
- --chain help updated for supported commands (token/portfolio/swap/ market kline·trending·trenches·hot-searches/track follow-*/order get/ gas-price); OpenApiClient chain comment
- docs: all SKILL.md, Readme.md, Readme.zh.md (split-out row for unsupported commands), cli-usage.md, plugin/marketplace descriptions

disable monad/megaeth/hyperevm/tron:
- comment monad out of VALID_CHAINS (kept for quick re-enable)
- strip these chains from all --chain help, SKILL.md, cli-usage.md (hot-searches default now 4 chains: sol/bsc/base/eth)