### PR TITLE
feat(chains): support robinhood on kol, smartmoney, signal and cooking

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -732,8 +732,8 @@ gmgn-cli cooking \
 | token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
 | swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC · eth: ETH |
 | gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
-| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` (kol/smartmoney) · `sol` / `bsc` (signal) — **no `robinhood`** | — |
-| cooking create | `sol` / `bsc` / `base` — **no `robinhood`** | — |
+| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` / `robinhood` (kol/smartmoney) · `sol` / `bsc` / `robinhood` (signal) | — |
+| cooking create | `sol` / `bsc` / `base` / `robinhood` | — |
 
 ---
 

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -756,8 +756,8 @@ gmgn-cli cooking \
 | token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
 | swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC · eth: ETH |
 | gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
-| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth`（kol/smartmoney）· `sol` / `bsc`（signal）— **不支持 `robinhood`** | — |
-| cooking create | `sol` / `bsc` / `base` — **不支持 `robinhood`** | — |
+| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` / `robinhood`（kol/smartmoney）· `sol` / `bsc` / `robinhood`（signal） | — |
+| cooking create | `sol` / `bsc` / `base` / `robinhood` | — |
 
 ---
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -325,7 +325,7 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` |
+| `--chain` | Yes | `sol` / `bsc` / `robinhood` |
 | `--signal-type` | No | Signal type(s), repeatable (1–18, default: all). See Signal Types below. |
 | `--mc-min` | No | Min market cap at trigger time (USD) |
 | `--mc-max` | No | Max market cap at trigger time (USD) |
@@ -476,7 +476,7 @@ gmgn-cli track kol [--chain <chain>] [--limit <n>] [--side <side>] [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | `sol` / `bsc` / `base` (default `sol`) |
+| `--chain` | No | `sol` / `bsc` / `base` / `eth` / `robinhood` (default `sol`) |
 | `--limit` | No | Page size (1–200, default 100) |
 | `--side` | No | Filter by trade direction: `buy` / `sell` (client-side filter) |
 
@@ -492,7 +492,7 @@ gmgn-cli track smartmoney [--chain <chain>] [--limit <n>] [--side <side>] [--raw
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | `sol` / `bsc` / `base` (default `sol`) |
+| `--chain` | No | `sol` / `bsc` / `base` / `eth` / `robinhood` (default `sol`) |
 | `--limit` | No | Page size (1–200, default 100) |
 | `--side` | No | Filter by trade direction: `buy` / `sell` (client-side filter) |
 
@@ -845,8 +845,8 @@ gmgn-cli cooking create \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` |
-| `--dex` | Yes | Launchpad per chain: `pump` / `bonk` / `bags` (sol), `fourmeme` / `flap` (bsc), `klik` / `clanker` (base) |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `robinhood` |
+| `--dex` | Yes | Launchpad per chain: `pump` / `bonk` / `bags` (sol), `fourmeme` / `flap` (bsc), `klik` / `clanker` (base), `trench` / `pons` (robinhood) |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--name` | Yes | Token name |
 | `--symbol` | Yes | Token symbol |
@@ -866,7 +866,7 @@ gmgn-cli cooking create \
 | `--max-priority-fee-per-gas` | No | Max priority fee per gas in wei (**EVM only**) |
 | `--anti-mev` | No | Enable anti-MEV protection (**SOL only**) |
 | `--anti-mev-mode` | No | Anti-MEV mode: `off` / `normal` / `secure` (**SOL only**) |
-| `--raised-token` | No | Raise token symbol: `pump`→`USDC`; `bonk`→`USD1`; `fourmeme`→`USDT`/`USD1`; omit for native |
+| `--raised-token` | No | Raise token symbol: `pump`→`USDC`; `bonk`→`USD1`; `fourmeme`→`USDT`/`USD1`; `base`/`robinhood`→native only; omit for native |
 | `--dev-wallet-bps` | No | Dev wallet fee share in basis points (100 = 1%) |
 | `--dev-gas` | No | Dev gas amount |
 | `--dev-priority` | No | Dev priority fee |

--- a/skills/gmgn-cooking/SKILL.md
+++ b/skills/gmgn-cooking/SKILL.md
@@ -60,15 +60,16 @@ This is a hard, code-level barrier — do not attempt to work around it. If a to
 
 ## Supported Chains
 
-`sol` / `bsc` / `base`
+`sol` / `bsc` / `base` / `robinhood`
 
 ## Supported Launchpads by Chain
 
-| Chain  | `--dex` values         | Raise token (`--raised-token`) |
-| ------ | ---------------------- | ------------------------------ |
-| `sol`  | `pump`, `bonk`, `bags` | `pump`: `""` (SOL) or `USDC`; `bonk`: `""` (SOL) or `USD1`; `bags`: `""` (SOL only) |
-| `bsc`  | `fourmeme`, `flap`     | `fourmeme`: `""` (BNB), `USD1`, `USDT`; `flap`: `""` (BNB only) |
-| `base` | `klik`, `clanker`      | `""` only (quote token fixed to WETH) |
+| Chain       | `--dex` values         | Raise token (`--raised-token`) |
+| ----------- | ---------------------- | ------------------------------ |
+| `sol`       | `pump`, `bonk`, `bags` | `pump`: `""` (SOL) or `USDC`; `bonk`: `""` (SOL) or `USD1`; `bags`: `""` (SOL only) |
+| `bsc`       | `fourmeme`, `flap`     | `fourmeme`: `""` (BNB), `USD1`, `USDT`; `flap`: `""` (BNB only) |
+| `base`      | `klik`, `clanker`      | `""` only (quote token fixed to WETH) |
+| `robinhood` | `trench`, `pons`       | `""` only (native token) |
 
 When the user names a platform colloquially (e.g. "pump.fun", "four.meme"), map it to the correct `--dex` identifier from this table before running the command.
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -927,7 +927,7 @@ Present each category separately with a header:
 
 ## `market signal` Parameters
 
-Chains: `sol` / `bsc` only. **Maximum 50 results per group** — use multiple groups via `--groups` to cover different signal types in a single request.
+Chains: `sol` / `bsc` / `robinhood` only. **Maximum 50 results per group** — use multiple groups via `--groups` to cover different signal types in a single request.
 
 **Single-group (individual flags):**
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-market
 description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.), and the hot-search ranking (most-searched tokens) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks for price chart, trending tokens, what's pumping, hot coins, most searched tokens, new launches, token signals, or wants to discover early-stage opportunities.
-argument-hint: "kline --chain <sol|bsc|base|eth|robinhood> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth|robinhood> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth|robinhood> | signal --chain <sol|bsc> | hot-searches [--chain <sol|bsc|base|eth|robinhood...>] [--interval <1m|5m|1h|6h|24h>]"
+argument-hint: "kline --chain <sol|bsc|base|eth|robinhood> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth|robinhood> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth|robinhood> | signal --chain <sol|bsc|robinhood> | hot-searches [--chain <sol|bsc|base|eth|robinhood...>] [--interval <1m|5m|1h|6h|24h>]"
 metadata:
   cliHelp: "gmgn-cli market --help"
 ---
@@ -50,12 +50,12 @@ Use the `gmgn-cli` tool to query K-line data for a token, browse trending tokens
 | `market kline` | Token candlestick / OHLCV data and trading volume over a time range |
 | `market trending` | Trending tokens ranked by swap activity — use `--interval` to specify the time window (e.g. `1m` for 1-minute hottest, `1h` for 1-hour trending) |
 | `market trenches` | Newly launched launchpad platform tokens — **use this when the user asks for "new tokens", "just launched tokens", "latest tokens on pump.fun/letsbonk"**. Three categories: `new_creation` (just created), `near_completion` (bonding curve almost full), `completed` (graduated to open market / DEX) |
-| `market signal` | Real-time token signal feed — price spikes, smart money buys, large buys, Dex ads, CTO events, and more. Results sorted by `trigger_at` descending. **sol / bsc only. Max 50 results per group.** |
+| `market signal` | Real-time token signal feed — price spikes, smart money buys, large buys, Dex ads, CTO events, and more. Results sorted by `trigger_at` descending. **sol / bsc / robinhood only. Max 50 results per group.** |
 | `market hot-searches` | Hot-search ranking — the most-searched tokens, ranked by `visiting_count` (search heat). **Use this when the user asks "what tokens are people searching for", "most searched tokens", "hot search list", "热搜榜".** Supports multiple chains in a single request. |
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood` (kline / trending / trenches; signal: `sol` / `bsc` only; hot-searches: `sol` / `bsc` / `base` / `eth` / `robinhood`)
+`sol` / `bsc` / `base` / `eth` / `robinhood` (kline / trending / trenches; signal: `sol` / `bsc` / `robinhood`; hot-searches: `sol` / `bsc` / `base` / `eth` / `robinhood`)
 
 ## Prerequisites
 

--- a/skills/gmgn-track/SKILL.md
+++ b/skills/gmgn-track/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-track
 description: Get real-time crypto buy/sell activity from Smart Money wallets, KOL influencer wallets, and personally followed wallets via GMGN API — alpha signals, whale tracking, meme token copy-trading ideas on Solana, BSC, Base, or Ethereum. Also query which tokens a wallet has followed (bookmarked) on GMGN. Use when user asks what smart money or KOLs are buying, wants whale alerts, on-chain alpha, copy-trade signals, or wants to check a wallet's followed tokens. (For a specific wallet address's portfolio, use gmgn-portfolio.)
-argument-hint: "<follow-tokens|follow-wallet|kol|smartmoney> --chain <sol|bsc|base|eth> [--wallet <wallet_address>]"
+argument-hint: "<follow-tokens|follow-wallet|kol|smartmoney> --chain <sol|bsc|base|eth|robinhood> [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli track --help"
 ---
@@ -60,8 +60,6 @@ Use the `gmgn-cli` tool to query on-chain tracking data based on the user's requ
 ## Supported Chains
 
 `sol` / `bsc` / `base` / `eth` / `robinhood`
-
-Note: `track kol` and `track smartmoney` do **not** support `robinhood` — they accept `sol` / `bsc` / `base` / `eth` only.
 
 ## Prerequisites
 

--- a/src/commands/cooking.ts
+++ b/src/commands/cooking.ts
@@ -22,8 +22,8 @@ export function registerCookingCommands(program: Command): void {
   cooking
     .command("create")
     .description("Create a token on a launchpad platform (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base")
-    .requiredOption("--dex <dex>", "Launchpad: pump / bonk / bags (sol) / fourmeme / flap (bsc) / klik / clanker (base)")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / robinhood")
+    .requiredOption("--dex <dex>", "Launchpad: pump / bonk / bags (sol) / fourmeme / flap (bsc) / klik / clanker (base) / trench / pons (robinhood)")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--name <name>", "Token name")
     .requiredOption("--symbol <symbol>", "Token symbol")
@@ -44,7 +44,7 @@ export function registerCookingCommands(program: Command): void {
     .option("--max-priority-fee-per-gas <amount>", "Max priority fee per gas in wei (EVM only)")
     .option("--anti-mev", "Enable anti-MEV protection (SOL only)")
     .option("--anti-mev-mode <mode>", "Anti-MEV mode: off / normal / secure (SOL only)")
-    .option("--raised-token <symbol>", "Raise token symbol: pump→USDC; bonk→USD1; fourmeme→USDT/USD1; leave empty for native")
+    .option("--raised-token <symbol>", "Raise token symbol: pump→USDC; bonk→USD1; fourmeme→USDT/USD1; base/robinhood→native only; leave empty for native")
     .option("--dev-wallet-bps <n>", "Dev wallet fee in basis points (100 = 1%)", parseInt)
     .option("--dev-gas <amount>", "Dev gas amount")
     .option("--dev-priority <amount>", "Dev priority fee")
@@ -84,10 +84,6 @@ export function registerCookingCommands(program: Command): void {
         process.exit(1);
       }
       validateChain(opts.chain);
-      if (opts.chain === "robinhood") {
-        console.error(`[gmgn-cli] cooking create does not support robinhood, got "${opts.chain}"`);
-        process.exit(1);
-      }
       // Validate/clean all free-text and link metadata before publishing. This
       // prevents the CLI from being used to mint tokens whose metadata carries a
       // prompt-injection payload aimed at other users' AI agents.

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -157,7 +157,7 @@ export function registerMarketCommands(program: Command): void {
   market
     .command("signal")
     .description("Query token signals (price spikes, smart money buys, large buys, etc.) — max 50 results per group")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / robinhood")
     .option("--signal-type <n...>", "Signal type(s), repeatable: 1–18 (default: all types)", (v: string, acc: number[]) => { acc.push(parseInt(v, 10)); return acc; }, [] as number[])
     .option("--mc-min <usd>", "Min market cap at trigger time (USD)", parseFloat)
     .option("--mc-max <usd>", "Max market cap at trigger time (USD)", parseFloat)
@@ -171,8 +171,8 @@ export function registerMarketCommands(program: Command): void {
     .option("--raw", "Output raw JSON")
     .action(async (opts: Record<string, unknown>) => {
       validateChain(opts["chain"] as string);
-      if (!["sol", "bsc"].includes(opts["chain"] as string)) {
-        console.error(`[gmgn-cli] market signal only supports sol and bsc, got "${opts["chain"]}"`);
+      if (!["sol", "bsc", "robinhood"].includes(opts["chain"] as string)) {
+        console.error(`[gmgn-cli] market signal only supports sol, bsc and robinhood, got "${opts["chain"]}"`);
         process.exit(1);
       }
 

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -76,16 +76,12 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("kol")
     .description("Get KOL trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .option("--limit <n>", "Page size (1–200, default 100)", parseInt)
     .option("--side <side>", "Filter by trade direction: buy / sell (client-side filter)")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (opts.chain) validateChain(opts.chain);
-      if (opts.chain === "robinhood") {
-        console.error(`[gmgn-cli] track kol does not support robinhood, got "${opts.chain}"`);
-        process.exit(1);
-      }
       const client = new OpenApiClient(getConfig());
       const data = await client.getKol(opts.chain, opts.limit).catch(exitOnError) as { list?: { side: string }[] };
       if (opts.side && data?.list) {
@@ -97,16 +93,12 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("smartmoney")
     .description("Get Smart Money trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .option("--limit <n>", "Page size (1–200, default 100)", parseInt)
     .option("--side <side>", "Filter by trade direction: buy / sell (client-side filter)")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       if (opts.chain) validateChain(opts.chain);
-      if (opts.chain === "robinhood") {
-        console.error(`[gmgn-cli] track smartmoney does not support robinhood, got "${opts.chain}"`);
-        process.exit(1);
-      }
       const client = new OpenApiClient(getConfig());
       const data = await client.getSmartMoney(opts.chain, opts.limit).catch(exitOnError) as { list?: { side: string }[] };
       if (opts.side && data?.list) {


### PR DESCRIPTION
## Summary
Brings the CLI in line with the backend, which now accepts `robinhood` on the four endpoints that previously rejected it (`kol`, `smartmoney`, `signal`, `cooking create-token`).

- Remove the robinhood-rejection guards in `track kol`, `track smartmoney`, `market signal`, and `cooking create-token`
- Update `--chain` / `--dex` / `--raised-token` help text and error messages
- cooking: robinhood launchpad uses `trench` / `pons` DEXes, native raised token only
- Sync all SKILL.md files, `docs/cli-usage.md`, and both `Readme.md` / `Readme.zh.md`

## Verification
- `npm run build` (tsc) passes clean
- Full-repo sweep confirms no stale robinhood-exclusion text remains

## ⚠️ Sequencing
This CLI change should merge **after** the openapi backend robinhood change is deployed to prod. Until then the CLI would forward `chain=robinhood` to a backend that still rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)