### PR TITLE
docs(market): extend signal_type range to 21 and name new types

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -326,7 +326,7 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 | Option | Required | Description |
 |--------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` / `robinhood` |
-| `--signal-type` | No | Signal type(s), repeatable (1–18, default: all). See Signal Types below. |
+| `--signal-type` | No | Signal type(s), repeatable (1–21, default: all). See Signal Types below. |
 | `--mc-min` | No | Min market cap at trigger time (USD) |
 | `--mc-max` | No | Max market cap at trigger time (USD) |
 | `--trigger-mc-min` | No | Min market cap at signal trigger moment (USD) |
@@ -359,6 +359,9 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 | 16 | SignalTypeMultiLargeBuy | Multiple large buys |
 | 17 | SignalTypeBagsClaims | Bags Claim |
 | 18 | SignalTypePumpClaims | Pump Claim |
+| 19 | SignalTypePlatformCallV2 | Platform call (V2) |
+| 20 | SignalTypeKOLBuy | KOL buy |
+| 21 | SignalTypeBankerClaims | Banker Claim (Base chain Banker platform claim fee) |
 
 ---
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -936,7 +936,7 @@ Do **not** pass signal types **14, 15, or 16** in `signal_type` / `--signal-type
 | Option | Required | Description |
 |--------|----------|-------------|
 | `--chain` | Yes | `sol` / `bsc` |
-| `--signal-type` | No | Signal type(s), repeatable (1–18, default: all). See Signal Types below. |
+| `--signal-type` | No | Signal type(s), repeatable (1–21, default: all). See Signal Types below. |
 | `--mc-min` | No | Min market cap at trigger time (USD) |
 | `--mc-max` | No | Max market cap at trigger time (USD) |
 | `--trigger-mc-min` | No | Min market cap at signal trigger moment (USD) |
@@ -977,6 +977,9 @@ gmgn-cli market signal --chain sol \
 | 16 | SignalTypeMultiLargeBuy | Multiple large buys |
 | 17 | SignalTypeBagsClaims | Bags Claim |
 | 18 | SignalTypePumpClaims | Pump Claim |
+| 19 | SignalTypePlatformCallV2 | Platform call (V2) |
+| 20 | SignalTypeKOLBuy | KOL buy |
+| 21 | SignalTypeBankerClaims | Banker Claim (Base chain Banker platform claim fee) |
 
 ### `market signal` Response Fields
 
@@ -986,7 +989,7 @@ Each item in the response array is one signal event:
 |-------|------|-------------|
 | `id` | string | Signal event ID |
 | `token_address` | string | Token contract address |
-| `signal_type` | number | Signal type (1–18, see Signal Types above) |
+| `signal_type` | number | Signal type (1–21, see Signal Types above) |
 | `trigger_at` | number | Unix timestamp (seconds) when the signal was triggered |
 | `trigger_mc` | number | Market cap at signal trigger time (USD) |
 | `first_trigger_mc` | number | Market cap at the very first trigger for this token (USD) |

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -158,7 +158,7 @@ export function registerMarketCommands(program: Command): void {
     .command("signal")
     .description("Query token signals (price spikes, smart money buys, large buys, etc.) — max 50 results per group")
     .requiredOption("--chain <chain>", "Chain: sol / bsc / robinhood")
-    .option("--signal-type <n...>", "Signal type(s), repeatable: 1–18 (default: all types)", (v: string, acc: number[]) => { acc.push(parseInt(v, 10)); return acc; }, [] as number[])
+    .option("--signal-type <n...>", "Signal type(s), repeatable: 1–21 (default: all types)", (v: string, acc: number[]) => { acc.push(parseInt(v, 10)); return acc; }, [] as number[])
     .option("--mc-min <usd>", "Min market cap at trigger time (USD)", parseFloat)
     .option("--mc-max <usd>", "Max market cap at trigger time (USD)", parseFloat)
     .option("--trigger-mc-min <usd>", "Min market cap at signal trigger (USD)", parseFloat)


### PR DESCRIPTION
## Summary

The OpenAPI backend now accepts `signal_type` **1–21** (previously 1–18). This aligns the gmgn-skills CLI help and docs, and names the three new types.

## New signal types

| Value | Name | Description |
| ----- | ---- | ----------- |
| 19 | `SignalTypePlatformCallV2` | Platform call (V2) |
| 20 | `SignalTypeKOLBuy` | KOL buy |
| 21 | `SignalTypeBankerClaims` | Banker Claim (Base chain Banker platform claim fee) |

## Changes

- `src/commands/market.ts` — `--signal-type` help text `1–18` → `1–21`
- `docs/cli-usage.md` — param note + signal-types table rows 19/20/21
- `skills/gmgn-market/SKILL.md` — param note, response-field note, signal-types table

The CLI does not range-validate `signal_type` client-side (values pass through), so 19–21 already worked functionally — this is a docs/help-text accuracy fix. Corresponds to the backend change in gmgn-openapi-service MR #45 + follow-up.

## Verification

- `npm run build` (tsc) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)