### PR TITLE
fix(holder-analysis): add robinhood to known chains to skip auto-detection

### DIFF
--- a/skills/gmgn-holder-analysis/analyze.py
+++ b/skills/gmgn-holder-analysis/analyze.py
@@ -8,7 +8,8 @@ CHAIN      = sys.argv[2]
 LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'
 
 # EVM 地址自动探测链（0x... 且 chain 传入 'auto' 或未明确指定时）
-if CHAIN == 'auto' or (TOKEN_ADDR.startswith('0x') and CHAIN not in ('bsc','eth','base')):
+KNOWN_CHAINS = ('bsc', 'eth', 'base', 'sol', 'robinhood')
+if CHAIN == 'auto' or (TOKEN_ADDR.startswith('0x') and CHAIN not in KNOWN_CHAINS):
     for _c in ('bsc', 'eth', 'base'):
         _r = subprocess.run(['gmgn-cli', 'token', 'holders', '--chain', _c,
                              '--address', TOKEN_ADDR, '--limit', '5', '--raw'],


### PR DESCRIPTION
## Problem

When `CHAIN` is explicitly passed as `robinhood`, the auto-detection logic in `analyze.py` treated it as an unknown chain (since the whitelist only contained `bsc`, `eth`, `base`) and silently fell back to probing all three chains — returning empty data and causing very slow analysis.

## Fix

Add a `KNOWN_CHAINS` tuple that includes `robinhood` (and `sol`). When the caller explicitly specifies a known chain, the probe is skipped entirely and the script queries the specified chain directly.

```python
KNOWN_CHAINS = ('bsc', 'eth', 'base', 'sol', 'robinhood')
if CHAIN == 'auto' or (TOKEN_ADDR.startswith('0x') and CHAIN not in KNOWN_CHAINS):
```

## Impact

- Robinhood chain holder analysis now works correctly and is significantly faster
- No behavior change for `bsc`, `eth`, `base`, `sol` chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)