### PR TITLE
feat(chains): add arc and stable across all commands and docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -729,10 +729,10 @@ gmgn-cli cooking \
 
 | Commands | Chains | Chain Currencies |
 |----------|--------|-----------------|
-| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
-| swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC · eth: ETH |
-| gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
-| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` / `robinhood` (kol/smartmoney) · `sol` / `bsc` / `robinhood` (signal) | — |
+| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` | — |
+| swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` | sol: SOL, USDC · bsc: BNB, USDC · base: ETH, USDC · eth: ETH |
+| gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` | — |
+| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` (kol/smartmoney) · `sol` / `bsc` / `robinhood` / `arc` / `stable` (signal) | — |
 | cooking create | `sol` / `bsc` / `base` / `robinhood` | — |
 
 ---

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -753,10 +753,10 @@ gmgn-cli cooking \
 
 | 接口类型 | 支持的链 | 链原生货币 |
 |----------|----------|-----------|
-| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
-| swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC · eth: ETH |
-| gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` | — |
-| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` / `robinhood`（kol/smartmoney）· `sol` / `bsc` / `robinhood`（signal） | — |
+| token / market / portfolio / track | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` | — |
+| swap / order | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` | sol: SOL、USDC · bsc: BNB、USDC · base: ETH、USDC · eth: ETH |
+| gas-price | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` | — |
+| track kol / track smartmoney · market signal | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`（kol/smartmoney）· `sol` / `bsc` / `robinhood` / `arc` / `stable`（signal） | — |
 | cooking create | `sol` / `bsc` / `base` / `robinhood` | — |
 
 ---

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -126,7 +126,7 @@ npx gmgn-cli market trending \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--interval` | Yes | `1m` / `5m` / `1h` / `6h` / `24h` |
 | `--limit` | No | Number of results (default 100, max 100) |
 | `--order-by` | No | Sort field: `volume` / `swaps` / `liquidity` / `marketcap` / `holders` / `price` / `change` / `change1m` / `change5m` / `change1h` / `renowned_count` / `smart_degen_count` / `bluechip_owner_percentage` / `rank` / `creation_timestamp` / `square_mentions` / `history_highest_market_cap` / `gas_fee` |
@@ -294,7 +294,7 @@ npx gmgn-cli market trenches --chain <chain> [--type <type...>] [--launchpad-pla
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
 | `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain). Values depend on chain — see below. |
 | `--limit` | No | Max results per category, max 80 (default: 80) |
@@ -325,7 +325,7 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `robinhood` / `arc` / `stable` |
 | `--signal-type` | No | Signal type(s), repeatable (1–21, default: all). See Signal Types below. |
 | `--mc-min` | No | Min market cap at trigger time (USD) |
 | `--mc-max` | No | Max market cap at trigger time (USD) |
@@ -370,7 +370,7 @@ gmgn-cli market signal --chain sol --groups '<json_array>' [--raw]
 Query the hot-search ranking — the most-searched tokens, ranked by `visiting_count` (search heat). Cross-chain top-500; one request can cover several chains at once. API Key auth only.
 
 ```bash
-# Default 5-chain set (sol/bsc/base/eth/robinhood, each 24h):
+# Default 7-chain set (sol/bsc/base/eth/robinhood/arc/stable, each 24h):
 gmgn-cli market hot-searches [--raw]
 
 # Specific chain(s) and interval:
@@ -382,7 +382,7 @@ gmgn-cli market hot-searches --params '<json_array>' [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | Repeatable: `sol` / `bsc` / `base` / `eth` / `robinhood`. Omit for the default 5-chain set. |
+| `--chain` | No | Repeatable: `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`. Omit for the default 7-chain set. |
 | `--interval` | No | `1m` / `5m` / `1h` / `6h` / `24h` (default `24h`). Applies to every `--chain`. |
 | `--limit` | No | Max results per chain (default `500`). |
 | `--filter` | No | Repeatable **boolean** filter tags (downstream `filter.filters`). sol defaults: `renounced` / `frozen`; EVM defaults: `not_honeypot` / `verified` / `renounced`. Recognised tags: `renounced` / `frozen` (sol) / `is_burnt` / `token_burnt` / `not_wash_trading` / `not_honeypot` (EVM) / `verified` (EVM) / `locked` (EVM) / `has_social` / `distribed` / `not_risk` / `img_not_duplicate` / `social_not_duplicate` / `creator_hold` / `creator_close` / `dexscr_update_link` / `launching` / `migrated` / `hide_b20` (base) / `hide_non_b20` (base). Unknown tags are silent no-ops. |
@@ -411,7 +411,7 @@ gmgn-cli track follow-tokens \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--wallet` | Yes | Wallet address |
 | `--group-id` | No | `all_group` (all tokens), `default`, or a user-defined group ID |
 | `--interval` | No | Time interval for price change stats: `1m` / `5m` / `1h` / `6h` / `24h` |
@@ -436,7 +436,7 @@ gmgn-cli track follow-token-groups \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--wallet` | Yes | Wallet address |
 
 ---
@@ -479,7 +479,7 @@ gmgn-cli track kol [--chain <chain>] [--limit <n>] [--side <side>] [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | `sol` / `bsc` / `base` / `eth` / `robinhood` (default `sol`) |
+| `--chain` | No | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` (default `sol`) |
 | `--limit` | No | Page size (1–200, default 100) |
 | `--side` | No | Filter by trade direction: `buy` / `sell` (client-side filter) |
 
@@ -495,7 +495,7 @@ gmgn-cli track smartmoney [--chain <chain>] [--limit <n>] [--side <side>] [--raw
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | No | `sol` / `bsc` / `base` / `eth` / `robinhood` (default `sol`) |
+| `--chain` | No | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` (default `sol`) |
 | `--limit` | No | Page size (1–200, default 100) |
 | `--side` | No | Filter by trade direction: `buy` / `sell` (client-side filter) |
 
@@ -565,7 +565,7 @@ npx gmgn-cli swap \
 
 | Option | Required | Chain | Description |
 |--------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--from` | Yes | all | Wallet address (must match the wallet bound to the API Key) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -582,7 +582,7 @@ npx gmgn-cli swap \
 | `--auto-fee` | No | `eth` | **Only with `--condition-orders`.** GMGN automatically selects the optimal fee. |
 | `--max-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max fee per gas |
 | `--max-priority-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max priority fee per gas |
-| `--condition-orders` | No | all | JSON array of take-profit/stop-loss conditions attached after a successful swap (see example below) |
+| `--condition-orders` | No | sol / bsc / base / eth / robinhood | JSON array of take-profit/stop-loss conditions attached after a successful swap (see example below). **Not supported on `arc` / `stable`.** |
 | `--sell-ratio-type` | No | all | **Only with `--condition-orders`.** Sell ratio base: `buy_amount` (default) / `hold_amount` |
 
 **`--condition-orders` example** (100% sell at 2× price, 100% sell at 50% price):
@@ -642,7 +642,7 @@ gmgn-cli multi-swap \
 
 | Option | Required | Chain | Description |
 |--------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--accounts` | Yes | all | Comma-separated wallet addresses (1–100, all bound to API Key) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -659,7 +659,7 @@ gmgn-cli multi-swap \
 | `--auto-fee` | No | `eth` | **Only with `--condition-orders`.** GMGN automatically selects the optimal fee. |
 | `--max-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max fee per gas |
 | `--max-priority-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max priority fee per gas |
-| `--condition-orders` | No | all | JSON array of take-profit/stop-loss conditions, attached to each successful wallet's swap (best-effort) |
+| `--condition-orders` | No | sol / bsc / base / eth / robinhood | JSON array of take-profit/stop-loss conditions, attached to each successful wallet's swap (best-effort). **Not supported on `arc` / `stable`.** |
 | `--sell-ratio-type` | No | all | **Only with `--condition-orders`.** Sell ratio base: `buy_amount` (default) / `hold_amount` |
 
 **Response fields (data):** Array of per-wallet results:
@@ -685,7 +685,7 @@ npx gmgn-cli order get --chain <chain> --order-id <order_id> [--raw]
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--order-id` | Yes | Order ID (returned by the `swap` command) |
 
 **Response fields (data):** Same structure as the `swap` response above.
@@ -720,11 +720,11 @@ gmgn-cli order strategy create \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | Base token contract address |
 | `--quote-token` | Yes | Quote token contract address |
-| `--order-type` | Yes | Order type: `limit_order` / `smart_trade` |
+| `--order-type` | Yes | Order type: `limit_order` / `smart_trade`. **`arc` / `stable` support `limit_order` only** — `smart_trade` returns a 400. |
 | `--sub-order-type` | Yes | `limit_order`: `buy_low` / `buy_high` / `stop_loss` / `take_profit`; `smart_trade` with condition_orders: `mix_trade` |
 | `--check-price` | No* | Trigger check price — required for `limit_order`; omit for `smart_trade` (trigger is in the `buy_low` condition order) |
 | `--open-price` | No | Open price of the position |
@@ -734,7 +734,7 @@ gmgn-cli order strategy create \
 | `--expire-in` | No | Order expiry in seconds |
 | `--sell-ratio-type` | No | `buy_amount` (default) / `hold_amount` |
 | `--quote-investment` | No | Quote token investment amount (`smart_trade`) |
-| `--condition-orders` | No | JSON array of condition sub-orders for `smart_trade`. Must include one `buy_low` entry (with `check_price` lower than `open_price`) plus at least one TP/SL entry |
+| `--condition-orders` | No | JSON array of condition sub-orders for `smart_trade`. Must include one `buy_low` entry (with `check_price` lower than `open_price`) plus at least one TP/SL entry. **Not supported on `arc` / `stable`** (`smart_trade` is rejected there). |
 | `--slippage` | No | Slippage tolerance as an integer 0–100, e.g. `30` = 30% |
 | `--auto-slippage` | No | Enable automatic slippage |
 | `--priority-fee` | No | Priority fee in SOL (**required for SOL chain**) |

--- a/skills/gmgn-holder-analysis/SKILL.md
+++ b/skills/gmgn-holder-analysis/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-holder-analysis
 description: Token holder chip analysis — deep analysis of holder structure including chip distribution, entry cost, whale/dev/KOL behavior, risk wallets (rat traders, bundlers, snipers), related wallets, smart money signals, and an AI rating based purely on token structure. Use when user asks about holder analysis, 筹码分析, 持仓分析, chip structure, who is holding, or whether a token is safe to buy based on its holder composition.
-argument-hint: "--chain <sol|bsc|base|eth|robinhood> --address <token_address>"
+argument-hint: "--chain <sol|bsc|base|eth|robinhood|arc|stable> --address <token_address>"
 metadata:
   cliHelp: "gmgn-cli token holders --help && gmgn-cli portfolio created-tokens --help"
 ---
@@ -797,7 +797,7 @@ Entry timing pressure (批次浮盈/出货) does **NOT** affect the overall rati
 
 ## Supported Chains
 
-`sol`, `bsc`, `base`, `eth`, `robinhood`
+`sol`, `bsc`, `base`, `eth`, `robinhood`, `arc`, `stable`
 
 ## Notes
 

--- a/skills/gmgn-holder-analysis/analyze.py
+++ b/skills/gmgn-holder-analysis/analyze.py
@@ -8,7 +8,7 @@ CHAIN      = sys.argv[2]
 LANG       = sys.argv[3] if len(sys.argv) > 3 else 'zh'
 
 # EVM 地址自动探测链（0x... 且 chain 传入 'auto' 或未明确指定时）
-KNOWN_CHAINS = ('bsc', 'eth', 'base', 'sol', 'robinhood')
+KNOWN_CHAINS = ('bsc', 'eth', 'base', 'sol', 'robinhood', 'arc', 'stable')
 if CHAIN == 'auto' or (TOKEN_ADDR.startswith('0x') and CHAIN not in KNOWN_CHAINS):
     for _c in ('bsc', 'eth', 'base'):
         _r = subprocess.run(['gmgn-cli', 'token', 'holders', '--chain', _c,

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-market
 description: Get crypto and meme token price charts (K-line, candlestick, OHLCV), trending meme coin rankings by volume, newly launched tokens on launchpads (pump.fun, fourmeme, letsbonk, Raydium, etc.), and the hot-search ranking (most-searched tokens) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks for price chart, trending tokens, what's pumping, hot coins, most searched tokens, new launches, token signals, or wants to discover early-stage opportunities.
-argument-hint: "kline --chain <sol|bsc|base|eth|robinhood> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth|robinhood> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth|robinhood> | signal --chain <sol|bsc|robinhood> | hot-searches [--chain <sol|bsc|base|eth|robinhood...>] [--interval <1m|5m|1h|6h|24h>]"
+argument-hint: "kline --chain <sol|bsc|base|eth|robinhood|arc|stable> --address <token_address> --resolution <30s|1m|5m|15m|1h|4h|1d> [--from <unix_ts>] [--to <unix_ts>] | trending --chain <sol|bsc|base|eth|robinhood|arc|stable> --interval <1m|5m|1h|6h|24h> | trenches --chain <sol|bsc|base|eth|robinhood|arc|stable> | signal --chain <sol|bsc|robinhood> | hot-searches [--chain <sol|bsc|base|eth|robinhood...>] [--interval <1m|5m|1h|6h|24h>]"
 metadata:
   cliHelp: "gmgn-cli market --help"
 ---
@@ -50,12 +50,12 @@ Use the `gmgn-cli` tool to query K-line data for a token, browse trending tokens
 | `market kline` | Token candlestick / OHLCV data and trading volume over a time range |
 | `market trending` | Trending tokens ranked by swap activity — use `--interval` to specify the time window (e.g. `1m` for 1-minute hottest, `1h` for 1-hour trending) |
 | `market trenches` | Newly launched launchpad platform tokens — **use this when the user asks for "new tokens", "just launched tokens", "latest tokens on pump.fun/letsbonk"**. Three categories: `new_creation` (just created), `near_completion` (bonding curve almost full), `completed` (graduated to open market / DEX) |
-| `market signal` | Real-time token signal feed — price spikes, smart money buys, large buys, Dex ads, CTO events, and more. Results sorted by `trigger_at` descending. **sol / bsc / robinhood only. Max 50 results per group.** |
+| `market signal` | Real-time token signal feed — price spikes, smart money buys, large buys, Dex ads, CTO events, and more. Results sorted by `trigger_at` descending. **sol / bsc / robinhood / arc / stable only. Max 50 results per group.** |
 | `market hot-searches` | Hot-search ranking — the most-searched tokens, ranked by `visiting_count` (search heat). **Use this when the user asks "what tokens are people searching for", "most searched tokens", "hot search list", "热搜榜".** Supports multiple chains in a single request. |
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood` (kline / trending / trenches; signal: `sol` / `bsc` / `robinhood`; hot-searches: `sol` / `bsc` / `base` / `eth` / `robinhood`)
+`sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` (kline / trending / trenches; signal: `sol` / `bsc` / `robinhood` / `arc` / `stable`; hot-searches: `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`)
 
 ## Prerequisites
 
@@ -85,7 +85,7 @@ When a request returns `429`:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--address` | Yes | Token contract address |
 | `--resolution` | Yes | Candlestick resolution: `30s` / `1m` / `5m` / `15m` / `1h` / `4h` / `1d` |
 | `--from` | No | Start time (Unix seconds) |
@@ -128,7 +128,7 @@ The response is an object with a `list` array. Each element in `list` is one can
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--interval` | Required. `1m` / `5m` / `1h` / `6h` / `24h` (default `1h`) |
 | `--limit <n>` | Number of results (default 100, max 100) |
 | `--order-by <field>` | Sort field: `default` / `swaps` / `marketcap` / `history_highest_market_cap` / `liquidity` / `volume` / `holder_count` / `smart_degen_count` / `renowned_count` / `gas_fee` / `price` / `change1m` / `change5m` / `change1h` / `creation_timestamp` |
@@ -542,7 +542,7 @@ Use field combinations to determine what stage a token is in. This affects how s
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--type` | No | Categories to query, repeatable: `new_creation` / `near_completion` / `completed` (default: all three) |
 | `--launchpad-platform` | No | Launchpad platform filter, repeatable (default: all platforms for the chain) |
 | `--limit` | No | Max results per category, max 80 (default: 80) |
@@ -927,7 +927,7 @@ Present each category separately with a header:
 
 ## `market signal` Parameters
 
-Chains: `sol` / `bsc` / `robinhood` only. **Maximum 50 results per group** — use multiple groups via `--groups` to cover different signal types in a single request.
+Chains: `sol` / `bsc` / `robinhood` / `arc` / `stable` only. **Maximum 50 results per group** — use multiple groups via `--groups` to cover different signal types in a single request.
 
 **Single-group (individual flags):**
 
@@ -1040,7 +1040,7 @@ Returns the hot-search ranking — the tokens people are searching for most righ
 
 | Option | Description |
 |--------|-------------|
-| `--chain <chain...>` | Repeatable. `sol` / `bsc` / `base` / `eth` / `robinhood`. **Omit to query the default 5-chain set** (sol / bsc / base / eth / robinhood, each at `24h` with chain-appropriate safety filters). |
+| `--chain <chain...>` | Repeatable. `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`. **Omit to query the default 7-chain set** (sol / bsc / base / eth / robinhood / arc / stable, each at `24h` with chain-appropriate safety filters). |
 | `--interval <interval>` | `1m` / `5m` / `1h` / `6h` / `24h` (default `24h`). Applies to every `--chain` provided. |
 | `--limit <n>` | Max results per chain (default `500`). |
 | `--filter <tag...>` | Repeatable **boolean** filter tags (the downstream `filter.filters` array). **⚠️ SOL defaults: `renounced frozen`; EVM defaults: `not_honeypot verified renounced`.** Omitting `--filter` is NOT "no filter" — the server applies chain defaults. See the Filter Tags table below for the exact vocabulary. |
@@ -1106,7 +1106,7 @@ Numeric bounds use the **same rank-style metric names as `market trending`**. Th
 
 **Notes on behaviour:**
 
-- `--chain all` is **not** valid. To aggregate across chains, pass `--chain` multiple times (or omit `--chain` for the default 5-chain set).
+- `--chain all` is **not** valid. To aggregate across chains, pass `--chain` multiple times (or omit `--chain` for the default 7-chain set).
 - When you pass `--chain` but omit `--filter`, the **server** applies the chain-appropriate default filters — so each chain is filtered even without an explicit `--filter`.
 - Different chains return different counts: a chain's token count depends on how many of its tokens made the global top-500 (sol is usually the largest).
 
@@ -1142,7 +1142,7 @@ See the [`market trending` Response Fields](#market-trending-response-fields) se
 ### `market hot-searches` Usage Examples
 
 ```bash
-# Default 5-chain hot-search ranking (sol/bsc/base/eth/robinhood, each 24h)
+# Default 7-chain hot-search ranking (sol/bsc/base/eth/robinhood/arc/stable, each 24h)
 gmgn-cli market hot-searches --raw
 
 # SOL only, 24h hot-search list
@@ -1185,7 +1185,7 @@ Present per chain, ranked by `visiting_count` (search heat):
 
 - `market kline`: `--from` and `--to` are Unix timestamps in **seconds** — CLI converts to milliseconds automatically
 - `market trending`: `--filter` and `--platform` are repeatable flags
-- `market hot-searches`: `--chain` and `--filter` are repeatable flags; omit `--chain` to query the default 5-chain set. `--min-*`/`--max-*` range flags reuse the same metric names as `market trending` and are translated server-side per `--interval`
+- `market hot-searches`: `--chain` and `--filter` are repeatable flags; omit `--chain` to query the default 7-chain set. `--min-*`/`--max-*` range flags reuse the same metric names as `market trending` and are translated server-side per `--interval`
 - All commands use exist auth (API Key only, no signature)
 - If the user doesn't provide kline timestamps, calculate them from the current time based on their desired time range
 - Use `--raw` to get single-line JSON for further processing

--- a/skills/gmgn-portfolio/SKILL.md
+++ b/skills/gmgn-portfolio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-portfolio
 description: Analyze any crypto wallet by address — holdings, realized/unrealized P&L, win rate, trading history, performance stats, specific token balance, and tokens created by a developer wallet (with ATH market cap and DEX graduation status) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks about a wallet's holdings, P&L, win rate, what tokens a dev has launched, the highest ATH token a dev ever created, or wants a wallet report to decide whether to copy-trade or follow.
-argument-hint: "<info|holdings|activity|stats|token-balance|created-tokens> [--chain <sol|bsc|base|eth|robinhood>] [--wallet <wallet_address>]"
+argument-hint: "<info|holdings|activity|stats|token-balance|created-tokens> [--chain <sol|bsc|base|eth|robinhood|arc|stable>] [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli portfolio --help"
 ---
@@ -45,7 +45,7 @@ Use the `gmgn-cli` tool to query wallet portfolio data based on the user's reque
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood`
+`sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`
 
 ## Prerequisites
 

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -68,7 +68,7 @@ This is a hard, code-level barrier — do not attempt to work around it.
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood`
+`sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`
 
 ## Chain Currencies
 
@@ -164,7 +164,7 @@ gmgn-cli swap \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -181,7 +181,7 @@ gmgn-cli swap \
 | `--auto-fee` | No | `eth` | **Only with `--condition-orders`.** GMGN automatically selects the optimal fee. |
 | `--max-fee-per-gas <n>` | No | `bsc` / `base` / `eth` | EIP-1559 max fee per gas. Clamped per chain minimums. Defaults to `--gas-price` if omitted (BASE/ETH). |
 | `--max-priority-fee-per-gas <n>` | No | `bsc` / `base` / `eth` | EIP-1559 max priority fee per gas. Clamped per chain minimums; capped to `--max-fee-per-gas`. |
-| `--condition-orders <json>` | No | all | JSON array of condition sub-orders (take-profit / stop-loss) to attach after a successful swap. **Max 10 sub-orders.** Strategy creation is best-effort: if the swap succeeds but strategy creation fails, the swap result is still returned. See ConditionOrder fields below. |
+| `--condition-orders <json>` | No | sol / bsc / base / eth / robinhood | JSON array of condition sub-orders (take-profit / stop-loss) to attach after a successful swap. **Max 10 sub-orders.** Strategy creation is best-effort: if the swap succeeds but strategy creation fails, the swap result is still returned. **Not supported on `arc` / `stable`.** See ConditionOrder fields below. |
 | `--sell-ratio-type <type>` | No | all | **Only with `--condition-orders`.** Sell ratio basis: `buy_amount` (default) — sells a fixed token amount stored at strategy creation time; `hold_amount` — sells a fixed percentage of the position held at trigger time |
 | `--yes` | No | all | Skip the interactive confirmation prompt. **Rejected unless `GMGN_ALLOW_AUTOMATED_TRADES=1` is set in the environment.** Do not use this to bypass human confirmation. |
 
@@ -383,7 +383,7 @@ gmgn-cli multi-swap \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--accounts` | Yes | all | Comma-separated wallet addresses (1–100, all must be bound to the API Key) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -400,7 +400,7 @@ gmgn-cli multi-swap \
 | `--auto-fee` | No | `eth` | **Only with `--condition-orders`.** GMGN automatically selects the optimal fee. |
 | `--max-fee-per-gas <amount>` | No | `bsc` / `base` / `eth` | EIP-1559 max fee per gas. Clamped per chain minimums. Defaults to `--gas-price` if omitted (BASE/ETH). |
 | `--max-priority-fee-per-gas <amount>` | No | `bsc` / `base` / `eth` | EIP-1559 max priority fee per gas. Clamped per chain minimums; capped to `--max-fee-per-gas`. |
-| `--condition-orders <json>` | No | all | JSON array of condition sub-orders (take-profit / stop-loss) attached to each successful wallet's swap. Same structure as `swap --condition-orders`. Strategy creation is best-effort per wallet. |
+| `--condition-orders <json>` | No | sol / bsc / base / eth / robinhood | JSON array of condition sub-orders (take-profit / stop-loss) attached to each successful wallet's swap. Same structure as `swap --condition-orders`. Strategy creation is best-effort per wallet. **Not supported on `arc` / `stable`.** |
 | `--sell-ratio-type <type>` | No | all | **Only with `--condition-orders`.** Sell ratio base: `buy_amount` (default) / `hold_amount`. |
 | `--yes` | No | all | Skip the interactive confirmation prompt. **Rejected unless `GMGN_ALLOW_AUTOMATED_TRADES=1` is set in the environment.** |
 
@@ -551,11 +551,11 @@ gmgn-cli order strategy create \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | all | Base token contract address |
 | `--quote-token` | Yes | all | Quote token contract address |
-| `--order-type` | Yes | all | Order type: `limit_order` / `smart_trade` |
+| `--order-type` | Yes | all | Order type: `limit_order` / `smart_trade`. **`arc` / `stable` support `limit_order` only** — `smart_trade` returns a 400. |
 | `--sub-order-type` | Yes | all | `limit_order`: `buy_low` / `buy_high` / `stop_loss` / `take_profit`; `smart_trade` with condition_orders: `mix_trade` |
 | `--check-price` | No* | all | Trigger price — required for `limit_order`; omit for `smart_trade` (trigger is in the `buy_low` condition order) |
 | `--open-price` | No | all | Open price of the position |
@@ -577,7 +577,7 @@ gmgn-cli order strategy create \
 | `--max-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max fee per gas. Clamped per chain minimums. |
 | `--max-priority-fee-per-gas` | No | `bsc` / `base` / `eth` | EIP-1559 max priority fee per gas. Clamped per chain minimums; capped to `--max-fee-per-gas`. |
 | `--anti-mev` | No | sol / bsc / eth | Enable anti-MEV protection. Not supported on `base`. |
-| `--condition-orders` | No | all | JSON array of condition sub-orders for `smart_trade`. Must include one `buy_low` entry (with `check_price` lower than `open_price`) plus at least one TP/SL entry. |
+| `--condition-orders` | No | sol / bsc / base / eth / robinhood | JSON array of condition sub-orders for `smart_trade`. Must include one `buy_low` entry (with `check_price` lower than `open_price`) plus at least one TP/SL entry. **Not supported on `arc` / `stable`** (`smart_trade` is rejected there). |
 | `--yes` | No | all | Skip the interactive confirmation prompt. **Rejected unless `GMGN_ALLOW_AUTOMATED_TRADES=1` is set in the environment.** |
 
 ### `order strategy create` Response Fields
@@ -609,7 +609,7 @@ gmgn-cli order strategy list --chain sol --group-tag STMix --base-token <token_a
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--type` | No | `open` (default) / `history` |
 | `--from` | No | Filter by wallet address |
 | `--group-tag` | Yes | Filter by order group: `LimitOrder` (limit orders only) / `STMix` (mixed strategy orders: take-profit, stop-loss, trailing take-profit, trailing stop-loss) |
@@ -633,7 +633,7 @@ gmgn-cli order strategy list --chain sol --group-tag STMix --base-token <token_a
 | `auto_slippage`            | bool   | Whether auto slippage is enabled |
 | `base_decimal`             | int    | Base token decimal places |
 | `base_token`               | string | Base token contract address |
-| `chain`                    | string | Chain: `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `chain`                    | string | Chain: `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `close_amount`             | string | Token amount sold on close; empty when order is open |
 | `close_price`              | string | Token price at close; empty when order is open |
 | `close_sell_model`         | string | Sell model used on close; empty when order is open |
@@ -747,7 +747,7 @@ gmgn-cli order strategy cancel \
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--order-id` | Yes | Order ID to cancel |
 | `--order-type` | No | Order type: `limit_order` (limit order) / `smart_trade` (mixed strategy order: take-profit, stop-loss, trailing take-profit, trailing stop-loss) |

--- a/skills/gmgn-token/SKILL.md
+++ b/skills/gmgn-token/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-token
 description: Research any crypto or meme token by address — real-time price, market cap, liquidity, holder list, trader list, top Smart Money and KOL positions, security audit (honeypot, rug pull risk, dev wallet, renounced status), social links (Twitter/X, website) via GMGN API on Solana, BSC, Base, or Ethereum. Use when user asks about a token's price, safety, holders, traders, smart money exposure, or wants due diligence before buying.
-argument-hint: "<sub-command> --chain <sol|bsc|base|eth|robinhood> --address <token_address>"
+argument-hint: "<sub-command> --chain <sol|bsc|base|eth|robinhood|arc|stable> --address <token_address>"
 metadata:
   cliHelp: "gmgn-cli token --help"
 ---
@@ -21,7 +21,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 ## Core Concepts
 
 - **Token address** — The on-chain contract address that uniquely identifies a token on its chain. Required for all token sub-commands. Format: base58 (SOL) or `0x...` hex (BSC/Base).
-- **Chain** — The blockchain network: `sol` = Solana, `bsc` = BNB Smart Chain, `base` = Base (Coinbase L2), `eth` = Ethereum mainnet, `robinhood` = Robinhood chain.
+- **Chain** — The blockchain network: `sol` = Solana, `bsc` = BNB Smart Chain, `base` = Base (Coinbase L2), `eth` = Ethereum mainnet, `robinhood` = Robinhood chain, `arc` = Arc chain, `stable` = Stable chain.
 - **Market cap** — Not returned directly by `token info`. Calculate as `price.price × circulating_supply` (`price` is a nested object; use `price.price` for the current USD price string).
 - **Liquidity** — USD value of token reserves in the main trading pool. Low liquidity (< $10k) means high price impact / slippage when buying or selling.
 - **Holder** — A wallet that currently holds the token. `token holders` returns wallets ranked by current balance.
@@ -46,7 +46,7 @@ Use the `gmgn-cli` tool to query token information based on the user's request.
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood`
+`sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`
 
 ## Prerequisites
 
@@ -76,7 +76,7 @@ When a request returns `429`:
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--address` | Yes | Token contract address |
 | `--raw` | No | Output raw single-line JSON (for piping or further processing) |
 
@@ -84,7 +84,7 @@ When a request returns `429`:
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `--chain` | Yes | — | `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Yes | — | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--address` | Yes | — | Token contract address |
 | `--limit` | No | `20` | Number of results, max `100` |
 | `--order-by` | No | `amount_percentage` | Sort field — see table below |

--- a/skills/gmgn-track/SKILL.md
+++ b/skills/gmgn-track/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-track
 description: Get real-time crypto buy/sell activity from Smart Money wallets, KOL influencer wallets, and personally followed wallets via GMGN API — alpha signals, whale tracking, meme token copy-trading ideas on Solana, BSC, Base, or Ethereum. Also query which tokens a wallet has followed (bookmarked) on GMGN. Use when user asks what smart money or KOLs are buying, wants whale alerts, on-chain alpha, copy-trade signals, or wants to check a wallet's followed tokens. (For a specific wallet address's portfolio, use gmgn-portfolio.)
-argument-hint: "<follow-tokens|follow-wallet|kol|smartmoney> --chain <sol|bsc|base|eth|robinhood> [--wallet <wallet_address>]"
+argument-hint: "<follow-tokens|follow-wallet|kol|smartmoney> --chain <sol|bsc|base|eth|robinhood|arc|stable> [--wallet <wallet_address>]"
 metadata:
   cliHelp: "gmgn-cli track --help"
 ---
@@ -59,7 +59,7 @@ Use the `gmgn-cli` tool to query on-chain tracking data based on the user's requ
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood`
+`sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`
 
 ## Prerequisites
 
@@ -130,7 +130,7 @@ gmgn-cli track smartmoney --chain sol --side sell --limit 10 --raw
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--wallet <address>` | Required. Wallet address to query |
 | `--group-id <id>` | Filter by group: `all_group` (all tokens across groups), `default` (default group), or a user-defined group ID |
 | `--interval <interval>` | Time interval for price change stats (e.g. `1m`, `5m`, `1h`, `6h`, `24h`) |
@@ -172,7 +172,7 @@ Each item in `followings` contains:
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--wallet <address>` | Required. Wallet address to query |
 
 ## `track follow-token-groups` Response Fields
@@ -190,7 +190,7 @@ Each item in `followings` contains:
 
 | Option | Description |
 |--------|-------------|
-| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` |
+| `--chain` | Required. `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
 | `--wallet <address>` | Filter by wallet address |
 | `--limit <n>` | Page size (1–100, default 10) |
 | `--side <side>` | Trade direction: `buy` / `sell` |

--- a/skills/gmgn-wallet-score/SKILL.md
+++ b/skills/gmgn-wallet-score/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-wallet-score
 description: Score any wallet address across three angles — profitability (a real track-record score: is this trader actually good?), copy-tradeability (can YOU actually capture what it makes, plus a latency/slippage/gas backtest), and Dev reputation (if it's mostly a token launcher, how trustworthy are its launches) — plus trading-style tags, all computed deterministically from GMGN portfolio data. Use when the user asks about a wallet's profitability ("这个钱包盈利能力怎么样", "钱包战绩怎么样", "is this wallet profitable"), copy-trade worthiness ("is this wallet worth following", "跟单评分", "钱包评分", "值不值得跟单", "if I copy this wallet what's my real return"), or token-launch/Dev reputation ("这个钱包发盘情况怎么样", "是不是发币方钱包", "dev 信誉怎么样", "is this a token-creator wallet"), or gives a wallet address and wants any of these judgments.
-argument-hint: "--chain <sol|bsc|base|eth|robinhood> --wallet <wallet_address> [--latency <seconds>] [--slippage <pct>] [--gas <usd>] [--sample <n>]"
+argument-hint: "--chain <sol|bsc|base|eth|robinhood|arc|stable> --wallet <wallet_address> [--latency <seconds>] [--slippage <pct>] [--gas <usd>] [--sample <n>]"
 metadata:
   cliHelp: "gmgn-cli portfolio stats --help && gmgn-cli portfolio activity --help && gmgn-cli portfolio created-tokens --help && gmgn-cli token security --help"
 ---
@@ -506,7 +506,7 @@ Fields the script reads, confirmed against `portfolio stats` / `portfolio activi
 
 ## Supported Chains
 
-`sol` / `bsc` / `base` / `eth` / `robinhood`
+`sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable`
 
 ## Prerequisites
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -187,7 +187,7 @@ export interface TokenSignalGroup {
 export interface HotSearchesParam {
   label?: string;
   interval: string;       // "1m" | "5m" | "1h" | "6h" | "24h"
-  chain: string;          // "sol" | "bsc" | "base" | "eth" | "robinhood"
+  chain: string;          // "sol" | "bsc" | "base" | "eth" | "robinhood" | "arc" | "stable"
   filters?: string[];
   limit?: number;
   [key: string]: string[] | number | string | undefined;

--- a/src/commands/market.ts
+++ b/src/commands/market.ts
@@ -26,7 +26,7 @@ export function registerMarketCommands(program: Command): void {
   market
     .command("kline")
     .description("Get token K-line (candlestick) data")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--address <address>", "Token contract address")
     .requiredOption("--resolution <resolution>", "Candlestick resolution: 30s / 1m / 5m / 15m / 1h / 4h / 1d")
     .option("--from <timestamp>", "Start time (Unix seconds)", parseInt)
@@ -51,7 +51,7 @@ export function registerMarketCommands(program: Command): void {
   const trendingCmd = market
     .command("trending")
     .description("Get trending token swap data")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--interval <interval>", "Time interval: 1m / 5m / 1h / 6h / 24h")
     .option("--limit <n>", "Number of results (default 100, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: default / volume / swaps / marketcap / holder_count / price / change1h / ... (see docs for full list)")
@@ -96,7 +96,7 @@ export function registerMarketCommands(program: Command): void {
   const trenchesCmd = market
     .command("trenches")
     .description("Get Trenches token data (new creation, near completion, completed)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .option("--type <type...>", "Categories to query, repeatable: new_creation / near_completion / completed (default: all three)")
     .option("--launchpad-platform <platform...>", "Launchpad platform filter, repeatable (default: all platforms for the chain)")
     .option("--limit <n>", "Max results per category, max 80 (default: 80)", parseInt)
@@ -157,7 +157,7 @@ export function registerMarketCommands(program: Command): void {
   market
     .command("signal")
     .description("Query token signals (price spikes, smart money buys, large buys, etc.) — max 50 results per group")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / robinhood / arc / stable")
     .option("--signal-type <n...>", "Signal type(s), repeatable: 1–21 (default: all types)", (v: string, acc: number[]) => { acc.push(parseInt(v, 10)); return acc; }, [] as number[])
     .option("--mc-min <usd>", "Min market cap at trigger time (USD)", parseFloat)
     .option("--mc-max <usd>", "Max market cap at trigger time (USD)", parseFloat)
@@ -171,8 +171,8 @@ export function registerMarketCommands(program: Command): void {
     .option("--raw", "Output raw JSON")
     .action(async (opts: Record<string, unknown>) => {
       validateChain(opts["chain"] as string);
-      if (!["sol", "bsc", "robinhood"].includes(opts["chain"] as string)) {
-        console.error(`[gmgn-cli] market signal only supports sol, bsc and robinhood, got "${opts["chain"]}"`);
+      if (!["sol", "bsc", "robinhood", "arc", "stable"].includes(opts["chain"] as string)) {
+        console.error(`[gmgn-cli] market signal only supports sol, bsc, robinhood, arc and stable, got "${opts["chain"]}"`);
         process.exit(1);
       }
 
@@ -207,7 +207,7 @@ export function registerMarketCommands(program: Command): void {
   const hotSearchesCmd = market
     .command("hot-searches")
     .description("Get the hot-search ranking (most-searched tokens) for one or more chains")
-    .option("--chain <chain...>", "Chain(s), repeatable: sol / bsc / base / eth / robinhood (default: all default chains)")
+    .option("--chain <chain...>", "Chain(s), repeatable: sol / bsc / base / eth / robinhood / arc / stable (default: all default chains)")
     .option("--interval <interval>", "Time window: 1m / 5m / 1h / 6h / 24h (default 24h)", "24h")
     .option("--limit <n>", "Max results per chain (default 500)", parseInt)
     .option("--filter <tag...>", "Boolean filter tags, repeatable. sol defaults: renounced / frozen; EVM defaults: not_honeypot / verified / renounced")

--- a/src/commands/portfolio.ts
+++ b/src/commands/portfolio.ts
@@ -10,7 +10,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("holdings")
     .description("Get wallet token holdings")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--limit <n>", "Page size (default 20, max 50)", parseInt, 20)
     .option("--cursor <cursor>", "Pagination cursor")
@@ -46,7 +46,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("activity")
     .description("Get wallet transaction activity")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--token <address>", "Filter by token contract address")
     .option("--limit <n>", "Page size", parseInt)
@@ -71,7 +71,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("stats")
     .description("Get wallet trading statistics (supports multiple wallets)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address...>", "Wallet address(es), repeatable")
     .option("--period <period>", "Stats period: 7d / 30d", "7d")
     .option("--raw", "Output raw JSON")
@@ -96,7 +96,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("token-balance")
     .description("Get wallet token balance for a single token")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address>", "Wallet address")
     .requiredOption("--token <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
@@ -112,7 +112,7 @@ export function registerPortfolioCommands(program: Command): void {
   portfolio
     .command("created-tokens")
     .description("Get tokens created by a developer wallet")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address>", "Developer wallet address")
     .option("--order-by <field>", "Sort field: market_cap / token_ath_mc")
     .option("--direction <dir>", "Sort direction: asc / desc")

--- a/src/commands/swap.ts
+++ b/src/commands/swap.ts
@@ -3,13 +3,13 @@ import { OpenApiClient, SwapParams, MultiSwapParams, StrategyCreateParams, Strat
 import { getConfig } from "../config.js";
 import { exitOnError, printResult } from "../output.js";
 import { confirmTrade } from "../confirm.js";
-import { validateAddress, validateChain, validatePercent, validatePositiveInt } from "../validate.js";
+import { validateAddress, validateChain, validateConditionOrdersSupported, validatePercent, validatePositiveInt } from "../validate.js";
 
 export function registerSwapCommands(program: Command): void {
   program
     .command("swap")
     .description("Submit a token swap")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -26,7 +26,7 @@ export function registerSwapCommands(program: Command): void {
     .option("--auto-fee", "Auto fee mode (eth only); delegates fee selection to trading bot for condition_orders strategy")
     .option("--max-fee-per-gas <amount>", "EIP-1559 max fee per gas (BSC / BASE / ETH)")
     .option("--max-priority-fee-per-gas <amount>", "EIP-1559 max priority fee per gas (BSC / BASE / ETH)")
-    .option("--condition-orders <json>", 'JSON array of take-profit/stop-loss conditions, e.g. \'[{"order_type":"profit_stop","side":"sell","price_scale":"150","sell_ratio":"100"}]\'; trace types: \'[{"order_type":"profit_stop_trace","side":"sell","price_scale":"150","sell_ratio":"100","drawdown_rate":"50"}]\'')
+    .option("--condition-orders <json>", 'JSON array of take-profit/stop-loss conditions, e.g. \'[{"order_type":"profit_stop","side":"sell","price_scale":"150","sell_ratio":"100"}]\'; trace types: \'[{"order_type":"profit_stop_trace","side":"sell","price_scale":"150","sell_ratio":"100","drawdown_rate":"50"}]\'; not supported on arc / stable')
     .option("--sell-ratio-type <type>", "Sell ratio base: buy_amount (default) / hold_amount; only used with --condition-orders")
     .option("--yes", "Skip the interactive confirmation prompt (requires GMGN_ALLOW_AUTOMATED_TRADES=1)")
     .option("--raw", "Output raw JSON")
@@ -61,6 +61,7 @@ export function registerSwapCommands(program: Command): void {
       if (opts.maxFeePerGas) params.max_fee_per_gas = opts.maxFeePerGas;
       if (opts.maxPriorityFeePerGas) params.max_priority_fee_per_gas = opts.maxPriorityFeePerGas;
       if (opts.conditionOrders) {
+        validateConditionOrdersSupported(opts.chain, "swap");
         try {
           params.condition_orders = JSON.parse(opts.conditionOrders);
         } catch {
@@ -92,7 +93,7 @@ export function registerSwapCommands(program: Command): void {
   program
     .command("multi-swap")
     .description("Submit token swaps across multiple wallets concurrently (up to 100 wallets)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--accounts <addresses>", "Comma-separated wallet addresses (all must be bound to the API Key)")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -109,7 +110,7 @@ export function registerSwapCommands(program: Command): void {
     .option("--auto-fee", "Auto fee mode (eth only); delegates fee selection to trading bot for condition_orders strategy")
     .option("--max-fee-per-gas <amount>", "EIP-1559 max fee per gas (BSC / BASE / ETH)")
     .option("--max-priority-fee-per-gas <amount>", "EIP-1559 max priority fee per gas (BSC / BASE / ETH)")
-    .option("--condition-orders <json>", "JSON array of take-profit/stop-loss conditions attached to each successful wallet's swap")
+    .option("--condition-orders <json>", "JSON array of take-profit/stop-loss conditions attached to each successful wallet's swap; not supported on arc / stable")
     .option("--sell-ratio-type <type>", "Sell ratio base: buy_amount (default) / hold_amount; only used with --condition-orders")
     .option("--yes", "Skip the interactive confirmation prompt (requires GMGN_ALLOW_AUTOMATED_TRADES=1)")
     .option("--raw", "Output raw JSON")
@@ -153,6 +154,7 @@ export function registerSwapCommands(program: Command): void {
       if (opts.maxFeePerGas) params.max_fee_per_gas = opts.maxFeePerGas;
       if (opts.maxPriorityFeePerGas) params.max_priority_fee_per_gas = opts.maxPriorityFeePerGas;
       if (opts.conditionOrders) {
+        validateConditionOrdersSupported(opts.chain, "multi_swap");
         try { params.condition_orders = JSON.parse(opts.conditionOrders); }
         catch { console.error("[gmgn-cli] --condition-orders must be valid JSON"); process.exit(1); }
       }
@@ -179,7 +181,7 @@ export function registerSwapCommands(program: Command): void {
   order
     .command("quote")
     .description("Get a swap quote without submitting a transaction (exist auth — GMGN_API_KEY only, no private key needed)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--from <address>", "Wallet address")
     .requiredOption("--input-token <address>", "Input token contract address")
     .requiredOption("--output-token <address>", "Output token contract address")
@@ -202,7 +204,7 @@ export function registerSwapCommands(program: Command): void {
   order
     .command("get")
     .description("Query order status (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--order-id <id>", "Order ID")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -214,8 +216,8 @@ export function registerSwapCommands(program: Command): void {
 
   program
     .command("gas-price")
-    .description("Query recommended gas price tiers for any chain (exist auth — API Key only; eth / bsc / base / sol / robinhood)")
-    .requiredOption("--chain <chain>", "Chain: eth / bsc / base / sol / robinhood")
+    .description("Query recommended gas price tiers for any chain (exist auth — API Key only; eth / bsc / base / sol / robinhood / arc / stable)")
+    .requiredOption("--chain <chain>", "Chain: eth / bsc / base / sol / robinhood / arc / stable")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
       const client = new OpenApiClient(getConfig(false));
@@ -228,11 +230,11 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("create")
     .description("Create a limit/strategy order (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--base-token <address>", "Base token contract address")
     .requiredOption("--quote-token <address>", "Quote token contract address")
-    .requiredOption("--order-type <type>", "Order type: limit_order / smart_trade")
+    .requiredOption("--order-type <type>", "Order type: limit_order / smart_trade (arc / stable support limit_order only)")
     .requiredOption("--sub-order-type <type>", "Sub-order type: buy_low / buy_high / stop_loss / take_profit (limit_order); mix_trade (smart_trade with condition_orders)")
     .option("--check-price <price>", "Trigger check price (required for limit_order; omit for smart_trade)")
     .option("--open-price <price>", "Open price of the position")
@@ -252,7 +254,7 @@ export function registerSwapCommands(program: Command): void {
     .option("--max-fee-per-gas <amount>", "EIP-1559 max fee per gas (BSC / BASE / ETH)")
     .option("--max-priority-fee-per-gas <amount>", "EIP-1559 max priority fee per gas (BSC / BASE / ETH)")
     .option("--anti-mev", "Enable anti-MEV protection")
-    .option("--condition-orders <json>", "JSON array of condition sub-orders for smart_trade (must include a buy_low entry + TP/SL entries)")
+    .option("--condition-orders <json>", "JSON array of condition sub-orders for smart_trade (must include a buy_low entry + TP/SL entries); smart_trade not supported on arc / stable")
     .option("--sell-param <json>", "JSON object of sell-side trade params used when a TP/SL condition fires (required for smart_trade)")
     .option("--buy-param <json>", "JSON object of buy-side trade params override for smart_trade")
     .option("--yes", "Skip the interactive confirmation prompt (requires GMGN_ALLOW_AUTOMATED_TRADES=1)")
@@ -267,6 +269,9 @@ export function registerSwapCommands(program: Command): void {
         process.exit(1);
       }
       validateChain(opts.chain);
+      if (opts.orderType === "smart_trade") {
+        validateConditionOrdersSupported(opts.chain, "strategy create (smart_trade)");
+      }
       const params: StrategyCreateParams = {
         chain: opts.chain,
         from_address: opts.from,
@@ -325,7 +330,7 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("list")
     .description("List strategy orders (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .option("--type <type>", "open (default) / history")
     .option("--from <address>", "Filter by wallet address")
     .option("--group-tag <tag>", "Filter by group: LimitOrder / STMix")
@@ -350,7 +355,7 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("cancel")
     .description("Cancel a strategy order (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--order-id <id>", "Order ID to cancel")
     .option("--order-type <type>", "Order type: limit_order / smart_trade")

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -10,7 +10,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("info")
     .description("Get token basic information and realtime price")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -24,7 +24,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("security")
     .description("Get token security metrics")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -38,7 +38,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("pool")
     .description("Get token liquidity pool information")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--address <address>", "Token contract address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -52,7 +52,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("holders")
     .description("Get top token holders")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--address <address>", "Token contract address")
     .option("--limit <n>", "Number of results (default 20, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: amount_percentage / profit / unrealized_profit / buy_volume_cur / sell_volume_cur", "amount_percentage")
@@ -75,7 +75,7 @@ export function registerTokenCommands(program: Command): void {
   token
     .command("traders")
     .description("Get top token traders")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--address <address>", "Token contract address")
     .option("--limit <n>", "Number of results (default 20, max 100)", parseInt)
     .option("--order-by <field>", "Sort field: amount_percentage / profit / unrealized_profit / buy_volume_cur / sell_volume_cur", "amount_percentage")

--- a/src/commands/track.ts
+++ b/src/commands/track.ts
@@ -10,7 +10,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-tokens")
     .description("Get the followed token list for a wallet on a given chain")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--group-id <id>", "Filter by group: all_group (all), default, or a user-defined group ID")
     .option("--interval <interval>", "Time interval for price change stats (e.g. 1m, 5m, 1h, 6h, 24h)")
@@ -38,7 +38,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-token-groups")
     .description("Get the follow token group names for a wallet on a given chain")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .requiredOption("--wallet <address>", "Wallet address")
     .option("--raw", "Output raw JSON")
     .action(async (opts) => {
@@ -51,7 +51,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("follow-wallet")
     .description("Get follow-wallet trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .option("--wallet <address>", "Filter by wallet address")
     .option("--limit <n>", "Page size (1–100, default 10)", parseInt)
     .option("--side <side>", "Trade direction filter: buy / sell")
@@ -76,7 +76,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("kol")
     .description("Get KOL trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .option("--limit <n>", "Page size (1–200, default 100)", parseInt)
     .option("--side <side>", "Filter by trade direction: buy / sell (client-side filter)")
     .option("--raw", "Output raw JSON")
@@ -93,7 +93,7 @@ export function registerTrackCommands(program: Command): void {
   track
     .command("smartmoney")
     .description("Get Smart Money trade records")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
     .option("--limit <n>", "Page size (1–200, default 100)", parseInt)
     .option("--side <side>", "Filter by trade direction: buy / sell (client-side filter)")
     .option("--raw", "Output raw JSON")

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,4 +1,4 @@
-const VALID_CHAINS = new Set(["sol", "bsc", "base", "eth", "robinhood" /*, "monad" */]);
+const VALID_CHAINS = new Set(["sol", "bsc", "base", "eth", "robinhood", "arc", "stable" /*, "monad" */]);
 const SOL_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 const POSITIVE_INT_RE = /^\d+$/;
@@ -13,7 +13,7 @@ export function validateChain(chain: string): void {
 }
 
 export function validateAddress(address: string, chain: string, label: string): void {
-  const isEvm = chain === "bsc" || chain === "base" || chain === "eth" || chain === "robinhood" /* || chain === "monad" */;
+  const isEvm = chain === "bsc" || chain === "base" || chain === "eth" || chain === "robinhood" || chain === "arc" || chain === "stable" /* || chain === "monad" */;
   const valid = isEvm ? EVM_ADDRESS_RE.test(address) : SOL_ADDRESS_RE.test(address);
   if (!valid) {
     console.error(
@@ -27,6 +27,18 @@ export function validatePositiveInt(value: string, label: string): void {
   if (!POSITIVE_INT_RE.test(value) || BigInt(value) <= 0n) {
     console.error(
       `[gmgn-cli] Invalid ${label}: "${value}". Must be a positive integer.`
+    );
+    process.exit(1);
+  }
+}
+
+// Chains that do not support condition orders / smart_trade strategies.
+const NO_CONDITION_ORDER_CHAINS = new Set(["arc", "stable"]);
+
+export function validateConditionOrdersSupported(chain: string, feature: string): void {
+  if (NO_CONDITION_ORDER_CHAINS.has(chain)) {
+    console.error(
+      `[gmgn-cli] condition orders are not supported on chain "${chain}" (${feature}). Use a plain swap or limit_order instead.`
     );
     process.exit(1);
   }


### PR DESCRIPTION
Add EVM chains **arc** and **stable** everywhere robinhood is supported, and gate the features they don't support.

## Changes

- **`src/validate.ts`** — add `arc` + `stable` to `VALID_CHAINS` and the EVM address check; add `NO_CONDITION_ORDER_CHAINS` set + `validateConditionOrdersSupported()` guard
- **`src/commands/{token,market,portfolio,swap,track}.ts`** — extend `--chain` option help and the market-signal chain gate
- **`src/commands/swap.ts`** — wire `validateConditionOrdersSupported()` into `swap`, `multi-swap` (`--condition-orders`), and `strategy create` (`--order-type smart_trade`)
- **`src/client/OpenApiClient.ts`** — `HotSearchesParam` chain comment
- Sync `SKILL.md` files, `Readme.md`, `Readme.zh.md`, `docs/cli-usage.md`; update the default hot-search set wording from 6-chain to 7-chain

## Notes

- **Condition orders / smart_trade are blocked on arc / stable** — CLI exits with a clear error; docs carry the "Not supported on `arc` / `stable`" notes throughout. arc / stable support `limit_order` only.
- Cooking/create_token remains sol/bsc/base/robinhood only (no launchpad on arc or stable), matching the openapi service.
- `npm run build` (tsc) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)