### PR TITLE
fix(market/cli): add arc/stable default launchpad platforms for trenches

### DIFF
--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -559,6 +559,8 @@ Use field combinations to determine what stage a token is in. This affects how s
 | `bsc`  | `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` |
 | `base` | `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik` |
 | `eth`  | `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
+| `arc`  | `dyorfun_v3` / `dyorswap` |
+| `stable` | `dyorswap` |
 
 ### Filter Presets
 
@@ -879,6 +881,62 @@ gmgn-cli market trenches --chain eth --raw \
 gmgn-cli market trenches --chain eth --raw \
   --type completed \
   --launchpad-platform trench --launchpad-platform clanker --launchpad-platform klik --launchpad-platform livo --launchpad-platform stroid --launchpad-platform pool_uniswap_v2 --launchpad-platform pool_uniswap_v3 --launchpad-platform printr \
+  --limit 80
+```
+
+### Arc Trenches Examples
+
+```bash
+# All three categories at once
+gmgn-cli market trenches --chain arc --raw \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --limit 80
+
+# New creation only
+gmgn-cli market trenches --chain arc --raw \
+  --type new_creation \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --limit 80
+
+# Near completion only
+gmgn-cli market trenches --chain arc --raw \
+  --type near_completion \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --limit 80
+
+# Completed (open market) only
+gmgn-cli market trenches --chain arc --raw \
+  --type completed \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --limit 80
+```
+
+### Stable Trenches Examples
+
+```bash
+# All three categories at once
+gmgn-cli market trenches --chain stable --raw \
+  --type new_creation --type near_completion --type completed \
+  --launchpad-platform dyorswap \
+  --limit 80
+
+# New creation only
+gmgn-cli market trenches --chain stable --raw \
+  --type new_creation \
+  --launchpad-platform dyorswap \
+  --limit 80
+
+# Near completion only
+gmgn-cli market trenches --chain stable --raw \
+  --type near_completion \
+  --launchpad-platform dyorswap \
+  --limit 80
+
+# Completed (open market) only
+gmgn-cli market trenches --chain stable --raw \
+  --type completed \
+  --launchpad-platform dyorswap \
   --limit 80
 ```
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -553,14 +553,16 @@ Use field combinations to determine what stage a token is in. This affects how s
 
 **`--launchpad-platform` values by chain** (omit `--launchpad-platform` to use all of the chain's platforms):
 
+> ⚠️ **arc and stable require explicit `--launchpad-platform`** — omitting it returns empty results for all categories. Always pass the platforms listed below when querying these two chains.
+
 | Chain | Platforms |
 |-------|-----------|
 | `sol`  | `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `ray_launchpad` / `meteora_virtual_curve` / `xstocks` |
 | `bsc`  | `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` |
 | `base` | `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik` |
 | `eth`  | `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
-| `arc`  | `dyorfun_v3` / `dyorswap` |
-| `stable` | `dyorswap` |
+| `arc`  | `dyorfun_v3` / `dyorswap` — **must be specified explicitly** |
+| `stable` | `dyorswap` — **must be specified explicitly** |
 
 ### Filter Presets
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -553,16 +553,14 @@ Use field combinations to determine what stage a token is in. This affects how s
 
 **`--launchpad-platform` values by chain** (omit `--launchpad-platform` to use all of the chain's platforms):
 
-> ⚠️ **arc and stable require explicit `--launchpad-platform`** — omitting it returns empty results for all categories. Always pass the platforms listed below when querying these two chains.
-
 | Chain | Platforms |
 |-------|-----------|
 | `sol`  | `Pump.fun` / `pump_mayhem` / `pump_mayhem_agent` / `pump_agent` / `letsbonk` / `bonkers` / `bags` / `memoo` / `liquid` / `bankr` / `zora` / `surge` / `anoncoin` / `moonshot_app` / `wendotdev` / `heaven` / `sugar` / `token_mill` / `believe` / `trendsfun` / `trends_fun` / `jup_studio` / `Moonshot` / `boop` / `ray_launchpad` / `meteora_virtual_curve` / `xstocks` |
 | `bsc`  | `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` |
 | `base` | `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik` |
 | `eth`  | `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
-| `arc`  | `dyorfun_v3` / `dyorswap` — **must be specified explicitly** |
-| `stable` | `dyorswap` — **must be specified explicitly** |
+| `arc`  | `dyorfun_v3` / `dyorswap` |
+| `stable` | `dyorswap` |
 
 ### Filter Presets
 

--- a/skills/gmgn-market/SKILL.md
+++ b/skills/gmgn-market/SKILL.md
@@ -559,8 +559,8 @@ Use field combinations to determine what stage a token is in. This affects how s
 | `bsc`  | `fourmeme` / `fourmeme_agent` / `bn_fourmeme` / `four_xmode_agent` / `cubepeg` / `likwid` / `goplus_creator` / `goplus_skills` / `openfour` / `flap` / `flap_stocks` / `flap_aioracle` / `clanker` / `lunafun` |
 | `base` | `clanker` / `bankr` / `flaunch` / `zora` / `zora_creator` / `baseapp` / `basememe` / `virtuals_v2` / `klik` |
 | `eth`  | `trench` / `clanker` / `klik` / `livo` / `stroid` / `pool_uniswap_v2` / `pool_uniswap_v3` / `printr` |
-| `arc`  | `dyorfun_v3` / `dyorswap` |
-| `stable` | `dyorswap` |
+| `arc`  | `dyorfun_v3` / `dyorswap` / `trench` / `onmifun` / `sharcfun` / `klik` |
+| `stable` | `dyorfun_v3` / `dyorswap` / `trench` |
 
 ### Filter Presets
 
@@ -890,25 +890,25 @@ gmgn-cli market trenches --chain eth --raw \
 # All three categories at once
 gmgn-cli market trenches --chain arc --raw \
   --type new_creation --type near_completion --type completed \
-  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench --launchpad-platform onmifun --launchpad-platform sharcfun --launchpad-platform klik \
   --limit 80
 
 # New creation only
 gmgn-cli market trenches --chain arc --raw \
   --type new_creation \
-  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench --launchpad-platform onmifun --launchpad-platform sharcfun --launchpad-platform klik \
   --limit 80
 
 # Near completion only
 gmgn-cli market trenches --chain arc --raw \
   --type near_completion \
-  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench --launchpad-platform onmifun --launchpad-platform sharcfun --launchpad-platform klik \
   --limit 80
 
 # Completed (open market) only
 gmgn-cli market trenches --chain arc --raw \
   --type completed \
-  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench --launchpad-platform onmifun --launchpad-platform sharcfun --launchpad-platform klik \
   --limit 80
 ```
 
@@ -918,25 +918,25 @@ gmgn-cli market trenches --chain arc --raw \
 # All three categories at once
 gmgn-cli market trenches --chain stable --raw \
   --type new_creation --type near_completion --type completed \
-  --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench \
   --limit 80
 
 # New creation only
 gmgn-cli market trenches --chain stable --raw \
   --type new_creation \
-  --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench \
   --limit 80
 
 # Near completion only
 gmgn-cli market trenches --chain stable --raw \
   --type near_completion \
-  --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench \
   --limit 80
 
 # Completed (open market) only
 gmgn-cli market trenches --chain stable --raw \
   --type completed \
-  --launchpad-platform dyorswap \
+  --launchpad-platform dyorfun_v3 --launchpad-platform dyorswap --launchpad-platform trench \
   --limit 80
 ```
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -846,6 +846,12 @@ const TRENCHES_PLATFORMS: Record<string, string[]> = {
     "noxa", "virtuals_v2", "bankr", "dyorswap",
     "pool_uniswap_v2", "pool_uniswap_v3", "pool_uniswap_v4",
   ],
+  arc: [
+    "dyorfun_v3", "dyorswap", "trench", "onmifun", "sharcfun", "klik",
+  ],
+  stable: [
+    "dyorfun_v3", "dyorswap", "trench",
+  ],
 };
 
 const TRENCHES_QUOTE_ADDRESS_TYPES: Record<string, number[]> = {


### PR DESCRIPTION
## Summary

- **SKILL.md**: 新增 arc/stable 两行至 `--launchpad-platform` 表格；新增 `Arc Trenches Examples` 和 `Stable Trenches Examples` 示例章节（与现有 sol/bsc/base/eth 格式一致）
- **OpenApiClient.ts**: 在 `TRENCHES_PLATFORMS` 中补全 arc/stable 默认平台列表，与网站保持一致

Arc 支持的平台（6个）：`dyorfun_v3` / `dyorswap` / `trench` / `onmifun` / `sharcfun` / `klik`
Stable 支持的平台（3个）：`dyorfun_v3` / `dyorswap` / `trench`

## Root Cause

`TRENCHES_PLATFORMS` 中缺少 arc/stable 条目，导致不指定 `--launchpad-platform` 时请求体 platforms 为空数组，三个类别均返回空结果：
```
{"completed":[],"new_creation":[],"pump":[]}
```

## Verification

实际 API 测试：arc 6个平台 + stable 3个平台，new_creation / near_completion / completed 三类均有数据返回。与 gmgn.ai 网站战壕页面显示的平台列表一致。

## Impact

- 不影响 sol/bsc/base/eth/robinhood 已有逻辑，仅新增两个 key
- 指定 `--launchpad-platform` 的调用不受影响（优先使用显式参数）