### PR TITLE
fix(holder-analysis): support arc/stable/robinhood chains in FILL_IN_CHAIN docs

### DIFF
--- a/skills/gmgn-holder-analysis/SKILL.md
+++ b/skills/gmgn-holder-analysis/SKILL.md
@@ -20,7 +20,7 @@ Run the following command, replacing the placeholders with the actual values:
 python3 ~/.claude/skills/gmgn-holder-analysis/analyze.py <FILL_IN_TOKEN_ADDRESS> <FILL_IN_CHAIN> <FILL_IN_LANG>
 ```
 
-- FILL_IN_CHAIN: `sol` for Solana addresses; for EVM `0x...` addresses use `auto` unless the user explicitly specifies a chain (`bsc`/`eth`/`base`)
+- FILL_IN_CHAIN: `sol` for Solana addresses; for EVM `0x...` addresses, use the chain the user specifies (`bsc`/`eth`/`base`/`robinhood`/`arc`/`stable`), otherwise use `auto`. Do NOT use `auto` when the user mentions arc, stable, or robinhood — pass the chain name directly.
 - FILL_IN_LANG: `zh` if user wrote Chinese, `en` if English, default `zh`
 
 ## Output Rule


### PR DESCRIPTION
## Problem

`SKILL.md` only listed `bsc/eth/base` in the `FILL_IN_CHAIN` hint, so Claude agents defaulted to `auto` for `arc`, `stable`, and `robinhood` addresses. This triggered a 3-chain probe (bsc→eth→base) that always returned empty results, causing holder analysis to silently fail or fall back to the wrong chain on these three chains.

## Fix

- Expand the chain list to all 6 EVM chains: `bsc`/`eth`/`base`/`robinhood`/`arc`/`stable`
- Add an explicit rule: **do NOT use `auto` for arc, stable, or robinhood** — pass the chain name directly

## Change

```diff
- FILL_IN_CHAIN: `sol` for Solana addresses; for EVM `0x...` addresses use `auto` unless the user explicitly specifies a chain (`bsc`/`eth`/`base`)
+ FILL_IN_CHAIN: `sol` for Solana addresses; for EVM `0x...` addresses, use the chain the user specifies (`bsc`/`eth`/`base`/`robinhood`/`arc`/`stable`), otherwise use `auto`. Do NOT use `auto` when the user mentions arc, stable, or robinhood — pass the chain name directly.
```

## Test

Verified holder analysis works correctly for arc and stable chain tokens after this fix (e.g. `0x8bcb94...`, `0xf3715b...` on arc).