### PR TITLE
docs: fix track subcommand headers mislabeled as portfolio in cli-usage

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -441,7 +441,7 @@ gmgn-cli track follow-token-groups \
 
 ---
 
-## portfolio follow-wallet
+## track follow-wallet
 
 Query follow-wallet trade records. Returns trades from wallets you personally follow on the GMGN platform. The follow list is resolved automatically from the GMGN user account bound to the API Key — `--wallet` is optional. Signed auth (API Key + private key signature).
 
@@ -469,7 +469,7 @@ gmgn-cli track follow-wallet \
 
 ---
 
-## portfolio kol
+## track kol
 
 Query KOL trade records.
 
@@ -485,7 +485,7 @@ gmgn-cli track kol [--chain <chain>] [--limit <n>] [--side <side>] [--raw]
 
 ---
 
-## portfolio smartmoney
+## track smartmoney
 
 Query Smart Money trade records.
 


### PR DESCRIPTION
In `docs/cli-usage.md`, the **follow-wallet**, **kol** and **smartmoney** sections are headed `## portfolio ...`, but these are `track` subcommands, not `portfolio`:

- They're registered under `track` in `src/commands/track.ts` (`program.command("track")` → `follow-wallet`, `kol`, `smartmoney`); `portfolio` has none of them.
- The fenced command block **directly under each header** already uses the correct form — `gmgn-cli track follow-wallet` / `track kol` / `track smartmoney`.
- `Readme.md` and `CLAUDE.md` also document these as `track`.

They were moved from `portfolio` into the new `track` group in #49, and these three headers were just never updated. Corrected the three headers `portfolio` → `track`.