### PR TITLE
fix: launch gmgn-cli from Windows in wallet-score analysis script

### DIFF
--- a/skills/gmgn-wallet-score/SKILL.md
+++ b/skills/gmgn-wallet-score/SKILL.md
@@ -45,7 +45,7 @@ Run this Python script inline, replacing the `<FILL_IN_*>` placeholders with the
 
 ```python
 python3 << 'PYEOF'
-import json, math, subprocess
+import json, math, os, shutil, subprocess
 
 CHAIN        = "<FILL_IN_CHAIN>"
 WALLET       = "<FILL_IN_WALLET_ADDRESS>"
@@ -59,7 +59,13 @@ ZH = (LANG == 'zh')
 def _(zh, en): return zh if ZH else en
 
 def run_cli(args, timeout=30):
-    r = subprocess.run(['gmgn-cli'] + args + ['--raw'], capture_output=True, text=True, timeout=timeout)
+    # On Windows, npm installs 'gmgn-cli' as a .cmd shim that subprocess cannot
+    # launch by bare name — resolve it through cmd.exe. Unix behavior unchanged.
+    cmd = ['gmgn-cli']
+    if os.name == 'nt':
+        exe = shutil.which('gmgn-cli') or 'gmgn-cli'
+        cmd = [os.environ.get('COMSPEC', 'cmd.exe'), '/c', exe] if exe.lower().endswith('.cmd') else [exe]
+    r = subprocess.run(cmd + args + ['--raw'], capture_output=True, text=True, timeout=timeout)
     if r.returncode != 0:
         raise RuntimeError(r.stderr)
     return json.loads(r.stdout)


### PR DESCRIPTION
## Problem

The `gmgn-wallet-score` analysis script (embedded in `SKILL.md`) invokes `subprocess.run(['gmgn-cli', ...])` with a bare command name. On Windows, `npm install -g gmgn-cli` installs a `.cmd` shim that cannot be launched by bare name via `CreateProcess`, so the skill crashes with `FileNotFoundError: [WinError 2]` on the very first `portfolio stats` call — the wallet never gets scored.

```
FileNotFoundError: [WinError 2] The system cannot find the file specified
  File "<gmgn-wallet-score-script>", line 15, in run_cli
    r = subprocess.run(['gmgn-cli'] + args + ['--raw'], ...)
```

## Fix

Resolve the command portably in `run_cli`:

- On Windows (`os.name == 'nt'`): look up the shim with `shutil.which('gmgn-cli')` and, since npm shims are `.cmd` files, launch it through `cmd.exe` (`COMSPEC`). Falls back to the bare name if no `.cmd` is found.
- On Unix: behavior is unchanged — `['gmgn-cli']` as before.

Only `run_cli` and the import line are touched; no scoring logic changes.

## Verification

- End-to-end on Windows against the live GMGN API: the script now pulls `portfolio stats` / `portfolio activity` / `portfolio created-tokens`, runs the Dev-reputation security scan (`token security`), and prints the full score report (scores, backtest, verdict) to completion, exit 0.
- The embedded script compiles cleanly with placeholders filled.
- The diff is limited to the process-launch plumbing (8 insertions, 2 deletions).

Note: independent of #194 — this fixes the Windows process launch; #194 fixes the frontmatter YAML that makes the skill installable. Both touch the same file; this one applies cleanly on top of either order.

Generated with Codebuff 🤖
Co-Authored-By: Codebuff <noreply@codebuff.com>