### PR TITLE
feat(strategy): add V2 strategy creation CLI

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -709,6 +709,15 @@ gmgn-cli order strategy list --chain sol
 
 # Cancel a strategy order
 gmgn-cli order strategy cancel --chain sol --from <wallet_address> --order-id <order_id>
+
+# Create a V2 smart-trade strategy
+gmgn-cli order strategy create-v2 \
+  --chain sol --from <wallet_address> \
+  --base-token <token_address> --quote-token So11111111111111111111111111111111111111112 \
+  --buy-type limit --quote-investment 1000000 \
+  --buy-order '{"order_type":"buy_low","side":"buy","check_price":"0.0185"}' \
+  --condition-orders '[{"order_type":"profit_stop","side":"sell","price_scale":"10","sell_ratio":"100"}]' \
+  --sell-param '{"slippage":30,"priority_fee":"0.0001","tip_fee":"0.00001"}'
 ```
 
 ### Cooking (requires private key)

--- a/Readme.zh.md
+++ b/Readme.zh.md
@@ -733,6 +733,15 @@ gmgn-cli order strategy list --chain sol
 
 # 撤销策略单
 gmgn-cli order strategy cancel --chain sol --from <wallet_address> --order-id <order_id>
+
+# 创建 V2 智能策略单
+gmgn-cli order strategy create-v2 \
+  --chain sol --from <wallet_address> \
+  --base-token <token_address> --quote-token So11111111111111111111111111111111111111112 \
+  --buy-type limit --quote-investment 1000000 \
+  --buy-order '{"order_type":"buy_low","side":"buy","check_price":"0.0185"}' \
+  --condition-orders '[{"order_type":"profit_stop","side":"sell","price_scale":"10","sell_ratio":"100"}]' \
+  --sell-param '{"slippage":30,"priority_fee":"0.0001","tip_fee":"0.00001"}'
 ```
 
 ### Cooking 一键策略单（需要私钥）

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -126,7 +126,7 @@ npx gmgn-cli market trending \
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--chain` | Yes | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
+| `--chain` | Yes | V1 supports `sol` / `bsc` / `base` / `eth` / `robinhood`; use `create-v2` for `arc` / `stable` |
 | `--interval` | Yes | `1m` / `5m` / `1h` / `6h` / `24h` |
 | `--limit` | No | Number of results (default 100, max 100) |
 | `--order-by` | No | Sort field: `volume` / `swaps` / `liquidity` / `marketcap` / `holders` / `price` / `change` / `change1m` / `change5m` / `change1h` / `renowned_count` / `smart_degen_count` / `bluechip_owner_percentage` / `rank` / `creation_timestamp` / `square_mentions` / `history_highest_market_cap` / `gas_fee` |
@@ -724,7 +724,7 @@ gmgn-cli order strategy create \
 | `--from` | Yes | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | Base token contract address |
 | `--quote-token` | Yes | Quote token contract address |
-| `--order-type` | Yes | Order type: `limit_order` / `smart_trade`. **`arc` / `stable` support `limit_order` only** — `smart_trade` returns a 400. |
+| `--order-type` | Yes | Order type: `limit_order` / `smart_trade` |
 | `--sub-order-type` | Yes | `limit_order`: `buy_low` / `buy_high` / `stop_loss` / `take_profit`; `smart_trade` with condition_orders: `mix_trade` |
 | `--check-price` | No* | Trigger check price — required for `limit_order`; omit for `smart_trade` (trigger is in the `buy_low` condition order) |
 | `--open-price` | No | Open price of the position |
@@ -755,6 +755,25 @@ gmgn-cli order strategy create \
 | `is_update` | bool | `true` if an existing order was updated |
 
 ---
+
+## order strategy create-v2
+
+Create a V2 smart-trade strategy through `POST /v2/trade/strategy/create`. It is independent from the V1 command.
+
+```bash
+gmgn-cli order strategy create-v2 \
+  --chain <chain> --from <wallet> \
+  --base-token <token> --quote-token <token> \
+  --buy-type <market|limit|position> \
+  --condition-orders <json-array> --sell-param <json-object> \
+  [--quote-investment <amount>] [--buy-order <json-object>] \
+  [--buy-param <json-object>] [--open-amount <amount>] \
+  [--open-price <price>] [--cost-price <price>] \
+  [--sell-ratio-type <buy_amount|hold_amount>] \
+  [--limit-price-mode <exact|slippage>] [--expire-in <seconds>] [--raw]
+```
+
+Market and limit entries require `--quote-investment`; limit also requires `--buy-order`. Position entries require `--open-amount` and `--open-price`. All JSON options are parsed before submission.
 
 ## order strategy list
 

--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gmgn-swap
 description: "[FINANCIAL EXECUTION] Buy and sell meme coins and crypto tokens on Solana, BSC, Base, or Ethereum — single swap, multi-wallet batch trading, limit orders, stop loss, take profit, trailing stop loss, trailing take profit via GMGN API. Requires explicit user confirmation. Use when user asks to buy, sell, or swap a token, trade from multiple wallets, set a limit order, stop loss, take profit, or check order status."
-argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>] | [gas-price --chain <eth|bsc|base|sol>] | [order strategy list --chain <chain> --group-tag <LimitOrder|STMix>] | [order strategy create --chain <chain> --order-type <limit_order|smart_trade> --sub-order-type <buy_low|buy_high|stop_loss|take_profit|mix_trade> ...]"
+argument-hint: "[--chain <chain> --from <wallet> --input-token <addr> --output-token <addr> --amount <n>] | [order get --chain <chain> --order-id <id>] | [gas-price --chain <chain>] | [order strategy create ...] | [order strategy create-v2 --buy-type <market|limit|position> ...]"
 metadata:
   cliHelp: "gmgn-cli swap --help"
 ---
@@ -38,7 +38,7 @@ Use the `gmgn-cli` tool to submit a token swap or query an existing order. `GMGN
 
 **This skill executes REAL, IRREVERSIBLE blockchain transactions.**
 
-- Every `swap` and `order strategy create` command submits an on-chain transaction that moves real funds.
+- Every `swap`, `order strategy create`, and `order strategy create-v2` command can move real funds.
 - Transactions cannot be undone once confirmed on-chain.
 - The AI agent must **never auto-execute a swap** — explicit user confirmation is required every time, without exception.
 - Only use this skill with funds you are willing to trade. Start with small amounts when testing.
@@ -62,7 +62,8 @@ This is a hard, code-level barrier — do not attempt to work around it.
 | `order quote` | Get a swap quote (no transaction submitted; exist auth — API Key only, no private key needed) |
 | `order get` | Query order status |
 | `gas-price` | Query recommended gas price (low / average / high tiers) for any chain; exist auth (API Key only) |
-| `order strategy create` | Create a limit/strategy order (requires private key) |
+| `order strategy create` | Create a V1 limit/strategy order (requires private key) |
+| `order strategy create-v2` | Create a V2 smart-trade strategy (requires private key) |
 | `order strategy list` | List strategy orders (requires private key) |
 | `order strategy cancel` | Cancel a strategy order (requires private key) |
 
@@ -100,6 +101,7 @@ All swap-related routes used by this skill go through GMGN's leaky-bucket limite
 | `order quote` | `GET /v1/trade/quote` | 2 |
 | `order get` | `GET /v1/trade/query_order` | 1 |
 | `order strategy create` | `POST /v1/trade/strategy/create` | 5 |
+| `order strategy create-v2` | `POST /v2/trade/strategy/create` | 5 |
 | `order strategy cancel` | `POST /v1/trade/strategy/cancel` | 2 |
 | `order strategy list` | `GET /v1/trade/strategy/orders` | 1 |
 | `gas-price` | `GET /v1/trade/gas_price` | 1 |
@@ -164,7 +166,7 @@ gmgn-cli swap \
 
 | Parameter | Required | Chain | Description |
 |-----------|----------|-------|-------------|
-| `--chain` | Yes | all | `sol` / `bsc` / `base` / `eth` / `robinhood` / `arc` / `stable` |
+| `--chain` | Yes | all | V1: `sol` / `bsc` / `base` / `eth` / `robinhood`; use `create-v2` for `arc` / `stable` |
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--input-token` | Yes | all | Input token contract address |
 | `--output-token` | Yes | all | Output token contract address |
@@ -555,7 +557,7 @@ gmgn-cli order strategy create \
 | `--from` | Yes | all | Wallet address (must match API Key binding) |
 | `--base-token` | Yes | all | Base token contract address |
 | `--quote-token` | Yes | all | Quote token contract address |
-| `--order-type` | Yes | all | Order type: `limit_order` / `smart_trade`. **`arc` / `stable` support `limit_order` only** — `smart_trade` returns a 400. |
+| `--order-type` | Yes | all | Order type: `limit_order` / `smart_trade` |
 | `--sub-order-type` | Yes | all | `limit_order`: `buy_low` / `buy_high` / `stop_loss` / `take_profit`; `smart_trade` with condition_orders: `mix_trade` |
 | `--check-price` | No* | all | Trigger price — required for `limit_order`; omit for `smart_trade` (trigger is in the `buy_low` condition order) |
 | `--open-price` | No | all | Open price of the position |
@@ -586,6 +588,25 @@ gmgn-cli order strategy create \
 |-------|------|-------------|
 | `order_id` | string | Created strategy order ID |
 | `is_update` | bool | `true` if an existing order was updated, `false` if newly created |
+
+## `order strategy create-v2` Usage
+
+V2 is a separate smart-trade contract; do not translate its fields into the V1 command.
+
+```bash
+gmgn-cli order strategy create-v2 \
+  --chain sol \
+  --from <wallet_address> \
+  --base-token <token_address> \
+  --quote-token So11111111111111111111111111111111111111112 \
+  --buy-type limit \
+  --quote-investment 1000000 \
+  --buy-order '{"order_type":"buy_low","side":"buy","check_price":"0.0185"}' \
+  --condition-orders '[{"order_type":"profit_stop","side":"sell","price_scale":"10","sell_ratio":"100"}]' \
+  --sell-param '{"slippage":30,"priority_fee":"0.0001","tip_fee":"0.00001"}'
+```
+
+All entry types require `--chain`, `--from`, `--base-token`, `--quote-token`, `--buy-type`, `--condition-orders`, and `--sell-param`. Market and limit entries require `--quote-investment`; limit also requires `--buy-order`. Position entries require `--open-amount` and `--open-price`. Supported chains are `sol`, `bsc`, `base`, `eth`, `robinhood`, `arc`, and `stable`.
 
 ---
 

--- a/src/client/OpenApiClient.ts
+++ b/src/client/OpenApiClient.ts
@@ -159,6 +159,26 @@ export interface StrategyCreateParams {
   buy_param?: TradeParam;
 }
 
+export interface StrategyCreateV2Params {
+  chain: string;
+  from_address: string;
+  base_token: string;
+  quote_token: string;
+  sub_order_type: "mix_trade";
+  buy_type: "market" | "limit" | "position";
+  condition_orders: Record<string, unknown>[];
+  sell_param: Record<string, unknown>;
+  quote_investment?: string;
+  buy_order?: Record<string, unknown>;
+  buy_param?: Record<string, unknown>;
+  open_amount?: string;
+  open_price?: string;
+  cost_price?: string;
+  sell_ratio_type?: string;
+  limit_price_mode?: string;
+  expire_in?: number;
+}
+
 export interface StrategyCancelParams {
   chain: string;
   from_address: string;
@@ -518,6 +538,10 @@ export class OpenApiClient {
 
   async createStrategyOrder(params: StrategyCreateParams): Promise<unknown> {
     return this.authSignedRequest("POST", "/v1/trade/strategy/create", {}, params);
+  }
+
+  async createStrategyOrderV2(params: StrategyCreateV2Params): Promise<unknown> {
+    return this.authSignedRequest("POST", "/v2/trade/strategy/create", {}, params);
   }
 
   async getStrategyOrders(chain: string, extra: Record<string, string | number> = {}): Promise<unknown> {

--- a/src/commands/swap.ts
+++ b/src/commands/swap.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
-import { OpenApiClient, SwapParams, MultiSwapParams, StrategyCreateParams, StrategyCancelParams } from "../client/OpenApiClient.js";
+import { OpenApiClient, SwapParams, MultiSwapParams, StrategyCreateParams, StrategyCreateV2Params, StrategyCancelParams } from "../client/OpenApiClient.js";
 import { getConfig } from "../config.js";
 import { exitOnError, printResult } from "../output.js";
 import { confirmTrade } from "../confirm.js";
-import { validateAddress, validateChain, validateConditionOrdersSupported, validatePercent, validatePositiveInt } from "../validate.js";
+import { validateAddress, validateChain, validateConditionOrdersSupported, validatePercent, validatePositiveInt, validateStrategyV1Chain } from "../validate.js";
 
 export function registerSwapCommands(program: Command): void {
   program
@@ -230,11 +230,11 @@ export function registerSwapCommands(program: Command): void {
   strategy
     .command("create")
     .description("Create a limit/strategy order (requires private key)")
-    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood")
     .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
     .requiredOption("--base-token <address>", "Base token contract address")
     .requiredOption("--quote-token <address>", "Quote token contract address")
-    .requiredOption("--order-type <type>", "Order type: limit_order / smart_trade (arc / stable support limit_order only)")
+    .requiredOption("--order-type <type>", "Order type: limit_order / smart_trade")
     .requiredOption("--sub-order-type <type>", "Sub-order type: buy_low / buy_high / stop_loss / take_profit (limit_order); mix_trade (smart_trade with condition_orders)")
     .option("--check-price <price>", "Trigger check price (required for limit_order; omit for smart_trade)")
     .option("--open-price <price>", "Open price of the position")
@@ -268,7 +268,7 @@ export function registerSwapCommands(program: Command): void {
         console.error("[gmgn-cli] Either --slippage or --auto-slippage must be provided");
         process.exit(1);
       }
-      validateChain(opts.chain);
+      validateStrategyV1Chain(opts.chain);
       if (opts.orderType === "smart_trade") {
         validateConditionOrdersSupported(opts.chain, "strategy create (smart_trade)");
       }
@@ -327,6 +327,8 @@ export function registerSwapCommands(program: Command): void {
       printResult(data, opts.raw);
     });
 
+  registerStrategyCreateV2(strategy);
+
   strategy
     .command("list")
     .description("List strategy orders (requires private key)")
@@ -374,4 +376,99 @@ export function registerSwapCommands(program: Command): void {
       const data = await client.cancelStrategyOrder(params).catch(exitOnError);
       printResult(data, opts.raw);
     });
+}
+
+function registerStrategyCreateV2(strategy: Command): void {
+  strategy
+    .command("create-v2")
+    .description("Create a V2 smart-trade strategy order (requires private key)")
+    .requiredOption("--chain <chain>", "Chain: sol / bsc / base / eth / robinhood / arc / stable")
+    .requiredOption("--from <address>", "Wallet address (must match API Key binding)")
+    .requiredOption("--base-token <address>", "Base token contract address")
+    .requiredOption("--quote-token <address>", "Quote token contract address")
+    .requiredOption("--buy-type <type>", "Entry type: market / limit / position")
+    .requiredOption("--condition-orders <json>", "JSON array of take-profit/stop-loss condition orders")
+    .requiredOption("--sell-param <json>", "JSON object of sell-side trade parameters")
+    .option("--quote-investment <amount>", "Quote investment in smallest units (market / limit)")
+    .option("--buy-order <json>", "JSON object describing the entry order (required for limit)")
+    .option("--buy-param <json>", "JSON object of buy-side trade parameters (market / limit)")
+    .option("--open-amount <amount>", "Existing position amount in smallest units (required for position)")
+    .option("--open-price <price>", "Existing position entry price (required for position)")
+    .option("--cost-price <price>", "Optional position cost price")
+    .option("--sell-ratio-type <type>", "Sell ratio basis: buy_amount / hold_amount")
+    .option("--limit-price-mode <mode>", "Limit price mode: exact / slippage")
+    .option("--expire-in <seconds>", "Order expiry in seconds", parseInt)
+    .option("--yes", "Skip the interactive confirmation prompt (requires GMGN_ALLOW_AUTOMATED_TRADES=1)")
+    .option("--raw", "Output raw JSON")
+    .action(async (opts) => {
+      validateChain(opts.chain);
+      validateAddress(opts.from, opts.chain, "--from");
+      validateAddress(opts.baseToken, opts.chain, "--base-token");
+      validateAddress(opts.quoteToken, opts.chain, "--quote-token");
+      if (!["market", "limit", "position"].includes(opts.buyType)) {
+        console.error("[gmgn-cli] --buy-type must be market, limit, or position");
+        process.exit(1);
+      }
+      if ((opts.buyType === "market" || opts.buyType === "limit") && !opts.quoteInvestment) {
+        console.error("[gmgn-cli] --quote-investment is required for market and limit entries");
+        process.exit(1);
+      }
+      if (opts.buyType === "limit" && !opts.buyOrder) {
+        console.error("[gmgn-cli] --buy-order is required for limit entries");
+        process.exit(1);
+      }
+      if (opts.buyType === "position" && (!opts.openAmount || !opts.openPrice)) {
+        console.error("[gmgn-cli] --open-amount and --open-price are required for position entries");
+        process.exit(1);
+      }
+      const params: StrategyCreateV2Params = {
+        chain: opts.chain,
+        from_address: opts.from,
+        base_token: opts.baseToken,
+        quote_token: opts.quoteToken,
+        sub_order_type: "mix_trade",
+        buy_type: opts.buyType,
+        condition_orders: parseJsonOption(opts.conditionOrders, "--condition-orders", true),
+        sell_param: parseJsonOption(opts.sellParam, "--sell-param", false),
+      };
+      if (opts.quoteInvestment) params.quote_investment = opts.quoteInvestment;
+      if (opts.buyOrder) params.buy_order = parseJsonOption(opts.buyOrder, "--buy-order", false);
+      if (opts.buyParam) params.buy_param = parseJsonOption(opts.buyParam, "--buy-param", false);
+      if (opts.openAmount) params.open_amount = opts.openAmount;
+      if (opts.openPrice) params.open_price = opts.openPrice;
+      if (opts.costPrice) params.cost_price = opts.costPrice;
+      if (opts.sellRatioType) params.sell_ratio_type = opts.sellRatioType;
+      if (opts.limitPriceMode) params.limit_price_mode = opts.limitPriceMode;
+      if (opts.expireIn != null) params.expire_in = opts.expireIn;
+      confirmTrade({
+        action: "Create V2 strategy order",
+        lines: [
+          `Chain:       ${params.chain}`,
+          `Wallet:      ${params.from_address}`,
+          `Base token:  ${params.base_token}`,
+          `Quote token: ${params.quote_token}`,
+          `Entry type:  ${params.buy_type}`,
+          `Amount:      ${params.quote_investment ?? params.open_amount}`,
+        ],
+      }, opts.yes);
+      const client = new OpenApiClient(getConfig(true));
+      const data = await client.createStrategyOrderV2(params).catch(exitOnError);
+      printResult(data, opts.raw);
+    });
+}
+
+function parseJsonOption(value: string, label: string, expectArray: true): Record<string, unknown>[];
+function parseJsonOption(value: string, label: string, expectArray: false): Record<string, unknown>;
+function parseJsonOption(value: string, label: string, expectArray: boolean): Record<string, unknown> | Record<string, unknown>[] {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const valid = expectArray
+      ? Array.isArray(parsed) && parsed.every((item) => item !== null && typeof item === "object" && !Array.isArray(item))
+      : parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+    if (!valid) throw new Error("wrong JSON shape");
+    return parsed as Record<string, unknown> | Record<string, unknown>[];
+  } catch {
+    console.error(`[gmgn-cli] ${label} must be valid JSON ${expectArray ? "array" : "object"}`);
+    process.exit(1);
+  }
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -12,6 +12,17 @@ export function validateChain(chain: string): void {
   }
 }
 
+const STRATEGY_V1_CHAINS = new Set(["sol", "bsc", "base", "eth", "robinhood"]);
+
+export function validateStrategyV1Chain(chain: string): void {
+  if (!STRATEGY_V1_CHAINS.has(chain)) {
+    console.error(
+      `[gmgn-cli] Invalid V1 strategy chain: "${chain}". Must be one of: ${[...STRATEGY_V1_CHAINS].join(", ")}. Use order strategy create-v2 for arc / stable.`
+    );
+    process.exit(1);
+  }
+}
+
 export function validateAddress(address: string, chain: string, label: string): void {
   const isEvm = chain === "bsc" || chain === "base" || chain === "eth" || chain === "robinhood" || chain === "arc" || chain === "stable" /* || chain === "monad" */;
   const valid = isEvm ? EVM_ADDRESS_RE.test(address) : SOL_ADDRESS_RE.test(address);


### PR DESCRIPTION
## Summary
- add `order strategy create-v2` backed by `POST /v2/trade/strategy/create`
- support market, limit, and existing-position entries with conditional validation
- parse and shape-check V2 JSON options before signing
- keep V1 on its original strategy chains; route arc/stable strategy creation to V2
- synchronize the skill, English/Chinese README, and CLI reference

## Validation
- `npm ci`
- `npm run build`
- `node dist/index.js order strategy create-v2 --help`
- verified missing limit `--buy-order` is rejected
- verified V1 rejects arc and points users to `create-v2`
- verified a valid V2 payload reaches the mandatory human-confirmation gate without submitting a live order