### PR TITLE
fix: the honeypot gate compares a boolean against "yes", so it never fires

### DIFF
--- a/skills/gmgn-swap/SKILL.md
+++ b/skills/gmgn-swap/SKILL.md
@@ -306,15 +306,15 @@ Sell:         {input amount in human units} {input token symbol}
 Buy:          {output token symbol}
 Slippage:     {slippage}% (or "auto")
 Est. output:  ~{output_amount from quote} {output token symbol}
-Risk Level:   🟢 Low / 🟡 Medium / 🔴 High  (based on rug_ratio from security check)
+Risk Level:   🟢 Low / 🟡 Medium / 🔴 High  (from the security check: honeypot / open-source / renounced / sell_tax / LP)
 
 Reply "confirm" to proceed.
 ```
 
-**Note**: `Risk Level` is derived from the required security check:
-- 🟢 Low: `rug_ratio < 0.1`
-- 🟡 Medium: `rug_ratio 0.1–0.3`
-- 🔴 High: `rug_ratio > 0.3` (requires re-confirmation)
+**Note**: `Risk Level` is derived from the required security check. `rug_ratio` is **not** in a `token security` response — it is a `market trending` / `market trenches` row field — so grade on what the endpoint actually returns:
+- 🔴 High (requires re-confirmation): `is_honeypot === true`, or `is_open_source === false`, or `sell_tax` above `0.10` once parsed, or LP neither locked (`lock_summary.is_locked`) nor burned (`burn_status == "burn"`)
+- 🟡 Medium: one of those cannot be cleared because the value is unavailable — `null` on SOL, `""` unreported, or `top_10_holder_rate: "0"` meaning not populated
+- 🟢 Low: honeypot `false`, contract open-source, ownership renounced, taxes `"0"`, LP locked or burned
 
 If the user explicitly skipped the security check, omit the Risk Level line and add a note: "(Security check skipped by user)"
 
@@ -796,8 +796,9 @@ gmgn-cli token security --chain <chain> --address <output_token>
 ```
 
 Check the two critical fields:
-- **`is_honeypot`**: If `"yes"` → **abort immediately**. Display: "🚫 HONEYPOT DETECTED — swap aborted." Do NOT proceed.
-- **`rug_ratio`**: If `> 0.3` → display 🔴 High Risk warning and require explicit re-confirmation from the user before proceeding.
+- **`is_honeypot`**: If `=== true` → **abort immediately**. Display: "🚫 HONEYPOT DETECTED — swap aborted." Do NOT proceed. The field is a **boolean**, so comparing it against `"yes"` never fires and every honeypot would pass. On SOL it is `null` — not applicable, not cleared.
+- **`sell_tax` / LP status**: If `sell_tax` parses above `0.10`, or LP is neither locked nor burned, or `is_open_source === false` → display 🔴 High Risk warning and require explicit re-confirmation from the user before proceeding. Do **not** gate on `rug_ratio` here; this endpoint does not return it.
+- **First confirm the token exists**: an unknown address returns a security block full of struct defaults. Check `info.symbol != ""` before trusting a clean result.
 
 **User override**: The user may explicitly skip this check by saying "I already checked" or "skip security check". In that case, document that the check was skipped in the confirmation summary. This is the only valid override — do NOT skip the check silently.
 

--- a/skills/gmgn-wallet-score/SKILL.md
+++ b/skills/gmgn-wallet-score/SKILL.md
@@ -224,13 +224,14 @@ if is_dev_wallet:
                     continue
                 checked += 1
                 bad = False
-                if str(sec.get('is_honeypot', '')).lower() == 'yes':
+                if _b(sec.get('is_honeypot')) or _b(sec.get('honeypot')):
                     bad = True
                 elif CHAIN == 'sol':
                     if not _b(sec.get('renounced_mint')) or not _b(sec.get('renounced_freeze_account')):
                         bad = True
                 else:
-                    if str(sec.get('open_source', '')).lower() == 'no':
+                    os_val = sec.get('is_open_source', sec.get('open_source'))
+                    if os_val is not None and not _b(os_val):
                         bad = True
                 if bad:
                     unsafe += 1
@@ -453,7 +454,7 @@ Fields the script reads, confirmed against `portfolio stats` / `portfolio activi
 | `portfolio activity` | `token.address`, `timestamp`, `price_usd` | Used for holding-duration and flip-rate detection |
 | `portfolio created-tokens` | `open_count`, `inner_count`, `open_ratio`, `creator_ath_info.ath_mc` | Dev launch-history survival stats |
 | `portfolio created-tokens` | `tokens[].is_open`, `tokens[].pool_liquidity`, `tokens[].create_timestamp`, `tokens[].token_address` | Per-launch alive/rugged classification |
-| `token security` | `is_honeypot`, `renounced_mint`, `renounced_freeze_account` (SOL), `open_source` (EVM) | Recent-launch security scan for Dev reputation |
+| `token security` | `is_honeypot` (boolean, `null` on SOL), `renounced_mint` / `renounced_freeze_account` (SOL), `is_open_source` (EVM boolean) | Recent-launch security scan for Dev reputation. Read through `_b()` — these are booleans with numeric aliases, never `"yes"` / `"no"` strings, and on SOL the aliases read `0` while the booleans are `null` |
 
 **Fields used defensively, not guaranteed present in every API response** — the script degrades gracefully (see [Notes](#notes)) rather than failing if these are absent:
 


### PR DESCRIPTION
## The bug

`token security` returns `is_honeypot` as a **boolean**. Two skills compared it against the string `"yes"`, which is never true for a boolean, so both checks were dead code that always read as clean.

`skills/gmgn-swap/SKILL.md:799`
```
- **`is_honeypot`**: If `"yes"` → **abort immediately**. Display: "🚫 HONEYPOT DETECTED — swap aborted."
```

`skills/gmgn-wallet-score/SKILL.md:227`
```python
if str(sec.get('is_honeypot', '')).lower() == 'yes':
```

The first sits on the money path — it is the pre-trade check meant to stop a swap into a token that cannot be sold.

## Measured against the live API, 2026-08-28

```
$ gmgn-cli token security --chain bsc --address 0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82 --raw   # CAKE
{"is_honeypot":false,"is_open_source":true,"is_renounced":true,"sell_tax":"0"}

$ gmgn-cli token security --chain sol --address EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v --raw  # USDC
{"is_honeypot":null,"honeypot":0,"is_open_source":null,"renounced_mint":true}
```

Booleans, `null` on Solana where the SPL model has no equivalent, plus numeric aliases (`honeypot: 0`) that are populated exactly where the booleans are not. No `"yes"` / `"no"` string anywhere in the response.

`rug_ratio` — the field `gmgn-swap` grades Risk Level on — is not in the response at all:

```
$ gmgn-cli token security … --raw | jq 'has("rug_ratio")'                    → false
$ gmgn-cli market trending … --raw | jq '.data.rank[0] | has("rug_ratio")'   → true
```

## What changed

**`skills/gmgn-swap/SKILL.md`**

- Honeypot abort is now `is_honeypot === true`, with the boolean shape and Solana's `null` spelled out so `null` reads as *not applicable* rather than *cleared*.
- Risk Level regraded onto fields this endpoint actually returns — honeypot / `is_open_source` / parsed `sell_tax` / LP locked-or-burned. `rug_ratio` dropped, with a note naming where it does live.
- Added a pre-check that `info.symbol != ""`: an address GMGN holds no record of returns a security block full of struct defaults, which otherwise reads as a clean token.

**`skills/gmgn-wallet-score/SKILL.md`** — this one contains executable Python.

- `_b()` applied to `is_honeypot` and its `honeypot` alias; open-source read as `is_open_source` falling back to `open_source`, and judged only when the value is not `None`.
- Field table row updated to name the shapes, so the next reader does not reintroduce the string comparison.

## Verified

Old vs new predicate, run on the exact code from both branches:

| case | old | new | expected |
|---|---|---|---|
| bsc honeypot | `False` — **missed** | `True` | `True` |
| bsc closed-source | `False` — **missed** | `True` | `True` |
| bsc CAKE, live values | `False` | `False` | `False` |
| sol USDC, live values | `False` | `False` | `False` |
| sol mint not renounced | `True` | `True` | `True` |

Consequence of those two misses in `gmgn-wallet-score`: `sec_risk_rate` stayed `0.0` for every wallet, so the `-0.35 * sec_risk_rate` term in the Dev-reputation score has never applied to anything.

Clean tokens and Solana's `null` are unchanged. No data gap is turned into a risk conclusion — `null` on Solana is reported as not applicable, never as cleared and never as a red flag.

## Scope

Two files, both of which *gate* on the field. Sibling files that only *describe* it — `gmgn-token`, `gmgn-market` and five `docs/workflow-*.md` — carry the same error but change no behaviour; happy to send those as a separate docs PR.

Markdown and embedded Python only, no `.ts` touched, so `build` and `pack` are unaffected.

Independent of #210 — different files, no overlap, either merge order works.
