### PR TITLE
docs: register gmgn-contract-dd in the routing tables, fix stale token-security field shapes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "gmgn-cli",
       "source": "./",
-      "description": "9 GMGN skills — token info & security, holder chip analysis, K-line market data & trending tokens, wallet portfolio analysis, wallet copy-trade scoring, follow/KOL/Smart Money tracking, DEX swap execution, and launchpad token creation, and chart pattern reading on top of that market data",
+      "description": "11 GMGN skills — token info & security, holder chip analysis, K-line market data & trending tokens, wallet portfolio analysis, wallet copy-trade scoring, follow/KOL/Smart Money tracking, DEX swap execution, and launchpad token creation, and chart pattern reading on top of that market data",
       "version": "1.0.0",
       "author": {
         "name": "GMGN"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,9 @@ This is a **Claude Code plugin** — a collection of GMGN OpenAPI skills for on-
 | Skill | Purpose | When to Use |
 |-------|---------|-------------|
 | `gmgn-token` | Token info, security, pool, holders, traders | User asks about a token's price, market cap, security risk, liquidity pool, top holders, or top traders; user wants to research a token before buying; user asks "is this token safe", "who holds this token", "what's the liquidity" |
+| `gmgn-contract-dd` | One 0-100 due-diligence composite for a token address — contract safety 0.45 + holder structure 0.35 + price action 0.20, every deduction naming the field it read, with a reported coverage that bounds the claim | User wants **one verdict number** rather than fields: 尽调, CA 尽调, 给这个币打个分, 这个币安全吗, 有没有貔貅, 能不能买, rug check, honeypot check, score this contract, due diligence. Refuses to score an address GMGN has no record of, and hands a bare wallet address to `gmgn-wallet-analysis` |
 | `gmgn-market` | K-line / candlestick market data + trending tokens + newly launched launchpad tokens | User asks for price history, chart data, OHLCV candles, trading volume over time; user wants to analyze price trends; user asks "show me the 1h chart", "what was the price last week", "give me kline data for this token"; user wants to discover hot or trending tokens; user asks "what tokens are trending", "show me top tokens by volume", "find hot tokens on SOL"; **user asks about newly launched tokens, fresh tokens, latest tokens on launchpads** — e.g. "show me new tokens on pump.fun", "what tokens just launched on SOL", "find newly created tokens", "latest tokens on letsbonk" → use `market trenches --type new_creation` |
+| `gmgn-wallet-analysis` | The copy-trade dossier on one wallet — four pass/fail gates, what it holds and buys now, entry market-cap band, copy window, size cap | User pastes a **bare wallet address**, or asks 「这个钱包能跟吗」, 「帮我分析一下这个钱包」, 「它现在在买什么」, "can I copy this wallet", "analyze this wallet". This is the default for a bare wallet address; `gmgn-portfolio` is for the raw holdings / P&L / activity behind it |
 | `gmgn-portfolio` | Wallet holdings, activity, trading stats, token balance | User asks about a wallet's holdings, P&L, transaction history, trading statistics, or token balance; user wants to analyze a wallet; user asks "what tokens does this wallet hold", "show me recent trades", "what's the win rate of this wallet" |
 | `gmgn-wallet-score` | Wallet scoring across three angles — profitability (track-record score), copy-tradeability (score + latency/slippage/gas backtest), and Dev reputation for token-creator wallets — plus trading-style tags | User asks about a wallet's profitability ("钱包盈利能力怎么样", "is this wallet profitable"), copy-trade worthiness ("is this wallet worth copying", "跟单评分", "钱包评分", "值不值得跟单", "if I copy this wallet what's my real return"), or launch/Dev reputation ("钱包发盘情况怎么样", "是不是发币方钱包", "dev 信誉怎么样"); user gives a wallet address and wants any of these judgments |
 | `gmgn-track` | Track trade activity of wallets I follow, KOL trades, Smart Money trades across chains | User asks about trades from wallets they follow; user wants to see what KOLs or Smart Money are buying/selling; user asks "show me what wallets I follow have traded recently", "what are KOLs buying", "show me smart money moves on BSC" |
@@ -40,7 +42,9 @@ Match the user's request to the right skill and workflow:
 
 | User says | Action |
 |-----------|--------|
-| "is this token safe", "check this token", "research this token", token address provided | `gmgn-token` → full workflow: `docs/workflow-token-research.md` |
+| "打个分", "尽调", "CA 尽调", "这个币安全吗", "能不能买", "rug check", "score this contract" — user wants **one number** | `gmgn-contract-dd` |
+| "check this token", "research this token", "what's the liquidity", "who holds this" — user wants **the fields** | `gmgn-token` → full workflow: `docs/workflow-token-research.md` |
+| bare token contract address, no question attached | `gmgn-contract-dd` for the verdict number, then offer `gmgn-token` for the raw fields. If the address turns out to be a wallet, `gmgn-wallet-analysis` |
 | "deep report", "full analysis", "全面分析这个项目", "深度报告", "值不值得重仓" | `gmgn-token` + `gmgn-market` → `docs/workflow-project-deep-report.md` |
 | "what's trending", "hot tokens", "top tokens by volume" | `gmgn-market trending` |
 | "走势怎么样", "什么形态", "is it breaking down" | `gmgn-kline-pattern` |
@@ -49,7 +53,7 @@ Match the user's request to the right skill and workflow:
 | "daily brief", "today's market", "每日简报", "今天市场怎么样", "聪明钱今天买了什么" | `gmgn-market` + `gmgn-track` → `docs/workflow-daily-brief.md` |
 | "what is smart money buying", "what are KOLs trading" | `gmgn-track smartmoney` / `gmgn-track kol` |
 | "wallets I follow", "my followed wallets traded" | `gmgn-track follow-wallet` |
-| "analyze this wallet", "is this wallet worth following", wallet address provided | `gmgn-portfolio` → full workflow: `docs/workflow-wallet-analysis.md` |
+| "analyze this wallet", "is this wallet worth following", bare wallet address provided | `gmgn-wallet-analysis` for the verdict dossier; `gmgn-portfolio` → `docs/workflow-wallet-analysis.md` when the raw holdings / P&L / activity are what is wanted |
 | "wallet style", "smart money profile", "聪明钱画像", "这个钱包是长线还是短线", "跟着他买收益如何", "聪明钱排行榜" | `gmgn-portfolio` + `gmgn-track` → `docs/workflow-smart-money-profile.md` |
 | "钱包盈利能力怎么样", "钱包战绩怎么样", "is this wallet profitable" | `gmgn-wallet-score` (profitability angle — track-record score) |
 | "跟单评分", "钱包评分", "值不值得跟单", "is this wallet worth copying", "copy trade score", wallet address provided + copy-trade decision | `gmgn-wallet-score` (copy-tradeability angle — score + backtest) |
@@ -72,7 +76,7 @@ Match the user's request to the right skill and workflow:
 ## Architecture
 
 - **`src/`** — TypeScript source (CLI commands, API client, signer)
-- **`skills/`** — 9 skill definitions for Claude Code
+- **`skills/`** — 11 skill definitions for Claude Code
 - **`dist/`** — Compiled output (generated by `npm run build`)
 - **`.claude-plugin/`** — Plugin metadata for Claude Code
 

--- a/docs/workflow-token-due-diligence.md
+++ b/docs/workflow-token-due-diligence.md
@@ -2,6 +2,8 @@
 
 Use this workflow before deciding to buy a token. Run all four steps in sequence.
 
+**If the user wants a single 0-100 verdict number rather than the fields, use the `gmgn-contract-dd` skill instead** — it scores the same responses on documented thresholds and reports a coverage figure. This document is the field-by-field read.
+
 ## Step 1 — Get basic info
 
 ```bash
@@ -18,20 +20,31 @@ Check: `price`, `liquidity`, `holder_count`, `wallet_tags_stat.smart_wallets`, `
 gmgn-cli token security --chain sol --address <token_address> --raw
 ```
 
-Check these fields and their safe thresholds:
+**These are booleans and numbers, not strings.** Verified against live responses on 2026-08-28: `is_honeypot`, `is_open_source`, `is_renounced` and `is_blacklist` are `true` / `false` / `null` — comparing any of them against `"yes"` or `"no"` can never be true. `null` means GMGN reported nothing, which is **not** the same as `false`; on Solana `is_honeypot` and `is_open_source` are `null` by design. The integer mirrors `honeypot` / `open_source` / `renounced` are not a safe substitute either: USDC returns `honeypot: 0` alongside `is_honeypot: null`, so `0` conflates "no" with "unknown".
 
 | Field | Safe | Warning | Danger |
 |-------|------|---------|--------|
-| `is_honeypot` | `"no"` | — | `"yes"` → Do not buy |
-| `open_source` | `"yes"` | `"unknown"` | `"no"` |
-| `owner_renounced` | `"yes"` | `"unknown"` | `"no"` |
+| `is_honeypot` | `false` | `null` → unknown, not safe | `true` → Do not buy |
+| `is_open_source` | `true` | `null` → unknown (always `null` on SOL) | `false` |
+| `is_renounced` | `true` | `null` → unknown | `false` |
+| `is_blacklist` | `false` | `null` → unknown | `true` → can bar an address from trading |
 | `renounced_mint` (SOL) | `true` | — | `false` → mint risk |
 | `renounced_freeze_account` (SOL) | `true` | — | `false` → freeze risk |
-| `buy_tax` / `sell_tax` | `0` | `0.01–0.05` | `>0.10` → high tax |
+| `buy_tax` / `sell_tax` | `"0"` | `0.01–0.05` | `>0.10` → high tax |
 | `top_10_holder_rate` | `<0.20` | `0.20–0.40` | `>0.50` → whale risk |
-| `rug_ratio` | `<0.10` | `0.10–0.30` | `>0.30` → high rug risk |
-| `creator_token_status` | `creator_close` | — | `creator_hold` → dev not sold |
-| `sniper_count` | `<5` | `5–20` | `>20` → heavily sniped |
+| `burn_status` / `lock_summary.is_locked` | `"burn"` or `is_locked: true` | `""` → not reported | neither locked nor burned |
+
+**Every rate and tax field is a decimal fraction**: `top_10_holder_rate: "0.1783"` is 17.83%, `buy_tax: "0.01"` is a 1% tax.
+
+**A `0` in these fields is not automatically a pass.** `top_10_holder_rate` comes back as the string `"0"` on Solana and on some EVM tokens — 0% top-ten concentration does not exist, so read that as *not reported* and fall back to `token info` → `stat.top_10_holder_rate`. For the taxes the two spellings differ: `"0"` on a populated block is a genuine 0% tax, while `""` means the block was never populated and the tax is unknown. Reading either blank as a safe zero is how a token with no security record reads as clean.
+
+**Three fields this table used to list are not returned by `token security` at all** — verified absent from every live response:
+
+- `rug_ratio` — it is a `market trending` / `market trenches` row field, not a security field. Read it there.
+- `creator_token_status` — it lives at `token info` → `dev.creator_token_status`.
+- `sniper_count` — like `rug_ratio`, it is a `market trending` / `market trenches` row field, not a security field. From `token info` the nearest equivalent is `stat.top70_sniper_hold_rate`.
+
+Also `owner_renounced` does not exist; the field is `is_renounced`.
 
 ## Step 3 — Check liquidity pool
 


### PR DESCRIPTION
Split out of #210 so that PR stays a single new `SKILL.md`. **Merge this after #210**, since the rows added here name a skill that does not exist on `main` until it lands.

Three files, `+29 −12`.

## CLAUDE.md — two routing collisions

The Quick Decision Guide sends `"is this token safe"`, `"check this token"` and *any* bare token address to `gmgn-token`. That collides head-on with the skill #210 adds, whose triggers are `这个币安全吗` / `能不能买` / `rug check` / a bare contract address — and with `gmgn-holder-analysis`, whose description also claims "whether a token is safe to buy". Three skills, one input, and the project-level doc pointing at the oldest of them.

Split by what the user actually wants:

| User says | Goes to |
|---|---|
| one number — 打个分, 尽调, 这个币安全吗, rug check | `gmgn-contract-dd` |
| the fields — check this token, what's the liquidity, who holds this | `gmgn-token` |
| bare contract address, no question | verdict first, fields offered after |

The same split was missing for wallets. `gmgn-wallet-analysis` claims the bare wallet address in its own description but **has no row anywhere in CLAUDE.md**, while a separate row sends "wallet address provided" to `gmgn-portfolio`. Added the row and split that route the same way: dossier verdict to `gmgn-wallet-analysis`, raw holdings / P&L / activity to `gmgn-portfolio`.

Also corrected two stale counts: `skills/` says 9 (it is 11 with #210), and the marketplace plugin description says `9 GMGN skills`.

## docs/workflow-token-due-diligence.md — the same field-shape bug #211 fixes in the skills

This doc is what someone follows when doing the read by hand, and its Step 2 table has been wrong. Verified against live responses on 2026-08-28:

- **`is_honeypot`, `is_open_source`, `is_renounced`, `is_blacklist` are `true` / `false` / `null`.** The doc compared them against `"yes"` and `"no"`, which can never be true — the same dead comparison #211 found on the money path in `gmgn-swap`. `null` is not `false`; on Solana the first two are `null` by design.
- **The integer mirrors are not a safe substitute.** USDC returns `honeypot: 0` alongside `is_honeypot: null`, so `0` conflates "no" with "unknown".
- **`owner_renounced` does not exist** — the field is `is_renounced`.
- **`rug_ratio` and `sniper_count` are not security fields** — both are `market trending` / `market trenches` row fields.
- **`creator_token_status` is not a security field** — it lives at `token info` → `dev.creator_token_status`.
- **`top_10_holder_rate` arrives as the string `"0"`** on Solana and on some EVM tokens, so the doc's `< 0.20` "safe" threshold read a struct default as a pass. Noted the `token info` → `stat.top_10_holder_rate` fallback, and that for the taxes `"0"` is a real 0% while `""` is unknown.

## Not in scope

`plugin.json` and `marketplace.json` are pinned at `1.0.0` while `package.json` is at `1.5.9`, and `gmgn-cooking` / `gmgn-holder-analysis` are still absent from the CLAUDE.md skill table. Left alone — pre-existing drift, not this PR's to fold in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)